### PR TITLE
Update installing_modules.rst

### DIFF
--- a/docs/usage/installing_modules.rst
+++ b/docs/usage/installing_modules.rst
@@ -26,6 +26,9 @@ to install Ansible however (via `pip`) puts the modules here
 To install the F5 modules in this repository, you can copy the contents of
 the `library/` directory we provide, into the location mentioned above.
 
+on MacOSX, the following location can be used for the modules:
+  * /Library/Frameworks/Python.framework/Versions/[PYTHON_VERSION]/lib/python[PYTHON_VERSION]/site-packages/ansible/modules/extras/network/f5
+
 In a relative location
 ----------------------
 


### PR DESCRIPTION
On MacOSX, it appears that the directory where ANSIBLE is installing modules is different, as the /usr/local/lib is not accessible for a standard user, even with "sudo".
Not sure if it makes sense to update the doc for this reason, but it can help ;-)