### PR TITLE
Fixes #133

### DIFF
--- a/library/bigip_pool2.py
+++ b/library/bigip_pool2.py
@@ -1,0 +1,631 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {
+    'status': ['preview'],
+    'supported_by': 'community',
+    'metadata_version': '1.0'
+}
+
+DOCUMENTATION = '''
+---
+module: bigip_pool
+short_description: "Manages F5 BIG-IP LTM pools"
+description:
+  - Manages F5 BIG-IP LTM pools via iControl REST API
+version_added: 1.2
+author:
+  - Tim Rupp (@caphrim007)
+  - Wojciech Wypior (@wojtek0806)
+notes:
+  - Requires BIG-IP software version >= 11
+  - F5 developed module 'F5-SDK' required (https://github.com/F5Networks/f5-common-python)
+  - Best run as a local_action in your playbook
+requirements:
+  - bigsuds
+options:
+  description:
+    description:
+      - Specifies descriptive text that identifies the pool.
+    required: false
+    version_added: "2.3"
+  state:
+    description:
+      - Pool/pool member state
+    required: false
+    default: present
+    choices:
+      - present
+      - absent
+    aliases: []
+  name:
+    description:
+      - Pool name
+    required: true
+    default: null
+    choices: []
+    aliases:
+      - pool
+  partition:
+    description:
+      - Partition of pool/pool member
+    required: false
+    default: 'Common'
+    choices: []
+    aliases: []
+  lb_method:
+    description:
+      - Load balancing method
+    version_added: "1.3"
+    required: False
+    default: 'round_robin'
+    choices:
+      - round_robin
+      - ratio_member
+      - least_connection_member
+      - observed_member
+      - predictive_member
+      - ratio_node_address
+      - least_connection_node_address
+      - fastest_node_address
+      - observed_node_address
+      - predictive_node_address
+      - dynamic_ratio
+      - fastest_app_response
+      - least_sessions
+      - dynamic_ratio_member
+      - l3_addr
+      - weighted_least_connection_member
+      - weighted_least_connection_node_address
+      - ratio_session
+      - ratio_least_connection_member
+      - ratio_least_connection_node_address
+    aliases: []
+  monitor_type:
+    description:
+      - Monitor rule type when monitors > 1
+    version_added: "1.3"
+    required: False
+    default: null
+    choices: ['and_list', 'm_of_n']
+    aliases: []
+  quorum:
+    description:
+      - Monitor quorum value when monitor_type is m_of_n
+    version_added: "1.3"
+    required: False
+    default: null
+    choices: []
+    aliases: []
+  monitors:
+    description:
+      - Monitor template name list. Always use the full path to the monitor.
+    version_added: "1.3"
+    required: False
+    default: null
+    choices: []
+    aliases: []
+  slow_ramp_time:
+    description:
+      - Sets the ramp-up time (in seconds) to gradually ramp up the load on
+        newly added or freshly detected up pool members
+    version_added: "1.3"
+    required: False
+    default: null
+    choices: []
+    aliases: []
+  reselect_tries:
+    description:
+      - Sets the number of times the system tries to contact a pool member
+        after a passive failure
+    version_added: "2.2"
+    required: False
+    default: null
+    choices: []
+    aliases: []
+  service_down_action:
+    description:
+      - Sets the action to take when node goes down in pool
+    version_added: "1.3"
+    required: False
+    default: null
+    choices:
+      - none
+      - reset
+      - drop
+      - reselect
+    aliases: []
+  host:
+    description:
+      - "Pool member IP"
+    required: False
+    default: null
+    choices: []
+    aliases:
+      - address
+  port:
+    description:
+      - Pool member port
+    required: False
+    default: null
+    choices: []
+    aliases: []
+extends_documentation_fragment: f5
+'''
+
+EXAMPLES = '''
+- name: Create pool
+  bigip_pool:
+      server: "lb.mydomain.com"
+      user: "admin"
+      password: "secret"
+      state: "present"
+      name: "my-pool"
+      partition: "Common"
+      lb_method: "least_connection_member"
+      slow_ramp_time: 120
+  delegate_to: localhost
+
+- name: Modify load balancer method
+  bigip_pool:
+      server: "lb.mydomain.com"
+      user: "admin"
+      password: "secret"
+      state: "present"
+      name: "my-pool"
+      partition: "Common"
+      lb_method: "round_robin"
+
+- name: Add pool member
+  bigip_pool:
+      server: "lb.mydomain.com"
+      user: "admin"
+      password: "secret"
+      state: "present"
+      name: "my-pool"
+      partition: "Common"
+      host: "{{ ansible_default_ipv4["address"] }}"
+      port: 80
+
+- name: Remove pool member from pool
+  bigip_pool:
+      server: "lb.mydomain.com"
+      user: "admin"
+      password: "secret"
+      state: "absent"
+      name: "my-pool"
+      partition: "Common"
+      host: "{{ ansible_default_ipv4["address"] }}"
+      port: 80
+
+- name: Delete pool
+  bigip_pool:
+      server: "lb.mydomain.com"
+      user: "admin"
+      password: "secret"
+      state: "absent"
+      name: "my-pool"
+      partition: "Common"
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.f5_utils import *
+from netaddr import IPAddress, AddrFormatError
+
+
+class Parameters(AnsibleF5Parameters):
+
+    api_map = {
+        'loadBalancingMode': 'lb_method', 'slowRampTime': 'slow_ramp_time',
+        'reselectTries': 'reselect_tries',
+        'serviceDownAction': 'service_down_action'
+               }
+
+    updatables = [
+        'monitor_type', 'quorum', 'monitors', 'service_down_action',
+        'description', 'lb_method', 'host', 'port', 'slow_ramp_time',
+        'reselect_tries'
+                    ]
+
+    returnables = [
+        'monitor_type', 'quorum', 'monitors', 'service_down_action',
+        'description', 'lb_method', 'host', 'port', 'monitor',
+        'slow_ramp_time', 'reselect_tries', 'name', 'member_name'
+    ]
+
+    api_attributes = [
+         'description', 'name', 'loadBalancingMode', 'monitor', 'slowRampTime',
+         'reselectTries', 'serviceDownAction'
+    ]
+
+    @property
+    def lb_method(self):
+        rawvalue = self._values['lb_method']
+        if rawvalue is None:
+            return None
+        value = rawvalue.replace('_', '-')
+        return value
+
+    @property
+    def monitors(self):
+        monitors = self._values['monitors']
+        monitor_type = self._values['monitor_type']
+        error1 = "The 'monitor_type' parameter cannot be empty when " \
+                 "'monitors' parameter is specified."
+        error2 = "The 'monitor' parameter cannot be empty when " \
+                 "'monitor_type' parameter is specified"
+        if monitors is not None and monitor_type is None:
+            raise F5ModuleError(error1)
+        if monitors is None and monitor_type is not None:
+            raise F5ModuleError(error2)
+        return monitors
+
+    @property
+    def quorum(self):
+        value = self._values['quorum']
+        error = "Quorum value must be specified with monitor_type 'm_of_n'."
+        if self._values['monitor_type'] == 'm_of_n' and value is None:
+            raise F5ModuleError(error)
+        return value
+
+    @property
+    def monitor(self):
+        monitors = self.monitors
+        monitor_type = self._values['monitor_type']
+        quorum = self.quorum
+
+        if monitors is None:
+            return None
+
+        if monitor_type == 'and_list':
+            and_list = list()
+            for m in monitors:
+                if monitors.index(m) == 0:
+                    and_list.append(m)
+                else:
+                    and_list.append('and')
+                    and_list.append(m)
+            result = ' '.join(and_list)
+        if monitor_type == 'm_of_n':
+            min_list = list()
+            prefix = 'min' + ' ' + str(quorum) + ' ' + 'of' + ' ' + '{'
+            min_list.append(prefix)
+            for m in monitors:
+                min_list.append(m)
+            min_list.append('}')
+            result = ' '.join(min_list)
+
+        return result
+
+    @property
+    def host(self):
+        value = self._values['host']
+        if value is None:
+            return None
+        msg = "'%s' is not a valid IP address" % value
+        try:
+            IPAddress(value)
+        except AddrFormatError:
+            raise F5ModuleError(msg)
+        return value
+
+    @host.setter
+    def host(self, value):
+        self._values['host'] = value
+
+    @property
+    def port(self):
+        value = self._values['port']
+        if value is None:
+            return None
+        msg = "The provided port '%s' must be between 0 and 65535" % value
+        if value < 0 or value > 65535:
+            raise F5ModuleError(msg)
+        return value
+
+    @port.setter
+    def port(self, value):
+        self._values['port'] = value
+
+    @property
+    def member_name(self):
+        if self.host is None or self.port is None:
+            return None
+        mname = str(self.host) + ':' + str(self.port)
+        return mname
+
+    def to_return(self):
+        result = {}
+        for returnable in self.returnables:
+            result[returnable] = getattr(self, returnable)
+        result = self._filter_params(result)
+        return result
+
+    def api_params(self):
+        result = {}
+        for api_attribute in self.api_attributes:
+            if self.api_map is not None and api_attribute in self.api_map:
+                result[api_attribute] = getattr(self,
+                                                self.api_map[api_attribute])
+            else:
+                result[api_attribute] = getattr(self, api_attribute)
+        result = self._filter_params(result)
+        return result
+
+
+class ModuleManager(object):
+    def __init__(self, client):
+        self.client = client
+        self.have = None
+        self.want = Parameters(self.client.module.params)
+        self.changes = Parameters()
+
+    def exec_module(self):
+        changed = False
+        result = dict()
+        state = self.want.state
+
+        try:
+            if state == "present":
+                changed = self.present()
+            elif state == "absent":
+                changed = self.absent()
+        except iControlUnexpectedHTTPError as e:
+            raise F5ModuleError(str(e))
+
+        changes = self.changes.to_return()
+        result.update(**changes)
+        result.update(dict(changed=changed))
+        return result
+
+    def _set_changed_options(self):
+        changed = {}
+        for key in Parameters.returnables:
+            if getattr(self.want, key) is not None:
+                changed[key] = getattr(self.want, key)
+        if changed:
+            self.changes = Parameters(changed)
+
+    def _update_changed_options(self):
+        changed = {}
+        for key in Parameters.updatables:
+            if getattr(self.want, key) is not None:
+                attr1 = getattr(self.want, key)
+                attr2 = getattr(self.have, key)
+                if attr1 != attr2:
+                    changed[key] = attr1
+        if changed:
+            self.changes = Parameters(changed)
+            return True
+        return False
+
+    def _member_does_not_exist(self, members):
+        name = self.want.member_name
+        # Return False if name is None, so that we don't attempt to create it
+        if name is None:
+            return False
+        for member in members:
+            if member.name == name:
+                host, port = name.split(':')
+                self.have.host = host
+                self.have.port = int(port)
+                return False
+        return True
+
+    def present(self):
+        if self.exists():
+            return self.update()
+        else:
+            return self.create()
+
+    def absent(self):
+        if self.exists():
+            return self.remove()
+        return False
+
+    def should_update(self):
+        result = self._update_changed_options()
+        if result:
+            return True
+        return False
+
+    def update(self):
+        self.have, members, poolres = self.read_current_from_device()
+        if self._member_does_not_exist(members):
+            self.create_member_on_device(poolres)
+        if not self.should_update():
+            return False
+        if self.client.check_mode:
+            return True
+        self.update_on_device()
+        return True
+
+    def remove(self):
+        if self.client.check_mode:
+            return True
+        self.remove_from_device()
+        if self.exists():
+            raise F5ModuleError("Failed to delete the Pool")
+        return True
+
+    def create(self):
+        self._set_changed_options()
+        if self.client.check_mode:
+            return True
+        self.create_on_device()
+        return True
+
+    def create_on_device(self):
+        params = self.want.api_params()
+        self.client.api.tm.ltm.pools.pool.create(
+            partition=self.want.partition, **params)
+
+    def create_member_on_device(self, poolres):
+        poolres.members_s.members.create(name=self.want.member_name,
+                                         partition=self.want.partition)
+
+    def update_on_device(self):
+        params = self.want.api_params()
+        result = self.client.api.tm.ltm.pools.pool.load(
+            name=self.want.name, partition=self.want.partition
+        )
+        result.modify(**params)
+
+    def exists(self):
+        return self.client.api.tm.ltm.pools.pool.exists(
+            name=self.want.name, partition=self.want.partition
+        )
+
+    def remove_from_device(self):
+        result = self.client.api.tm.ltm.pools.pool.load(
+            name=self.want.name, partition=self.want.partition
+        )
+        member = result.members_s.members.load(name=self.want.member_name,
+                                               partition=self.want.partition)
+        if member:
+            member.delete()
+            self.delete_node_on_device()
+        if result:
+            result.delete()
+
+    def read_current_from_device(self):
+        tmp_res = self.client.api.tm.ltm.pools.pool.load(
+            name=self.want.name, partition=self.want.partition
+        )
+        members = tmp_res.members_s.get_collection()
+
+        result = tmp_res.attrs
+        return Parameters(result), members, tmp_res
+
+    def delete_node_on_device(self):
+        node = self.client.api.tm.ltm.nodes.node.load(
+            name=self.want.host, partition=self.want.partition)
+        try:
+            node.delete()
+        except iControlUnexpectedHTTPError as e:
+            # If we cannot remove it, it is in use, it is up to user to delete
+            # it later.
+            if "is referenced by a member of pool" in str(e):
+                return
+            else:
+                raise
+
+
+class ArgumentSpec(object):
+    def __init__(self):
+        self.lb_choice = [
+            'round_robin', 'ratio_member', 'least_connection_member',
+            'observed_member', 'predictive_member', 'ratio_node_address',
+            'least_connection_node_address', 'fastest_node_address',
+            'observed_node_address', 'predictive_node_address',
+            'dynamic_ratio', 'fastest_app_response', 'least_sessions',
+            'dynamic_ratio_member', 'l3_addr', 'ratio_session'
+            'weighted_least_connection_member', 'ratio_least_connection_member'
+            'weighted_least_connection_node_address',
+            'ratio_least_connection_node_address'
+        ]
+        self.supports_check_mode = True
+        self.argument_spec = dict(
+            name=dict(
+                required=True,
+                aliases=['pool']
+            ),
+            lb_method=dict(
+                required=False,
+                choices=self.lb_choice,
+                default=None
+            ),
+            monitor_type=dict(
+                required=False,
+                choices=[
+                    'and_list', 'm_of_n'
+                ],
+                default=None
+            ),
+            quorum=dict(
+                required=False,
+                default=None,
+                type='int'
+            ),
+            monitors=dict(
+                required=False,
+                default=None,
+                type='list'
+            ),
+            slow_ramp_time=dict(
+                required=False,
+                default=None,
+                type='int'
+            ),
+            reselect_tries=dict(
+                required=False,
+                default=None,
+                type='int'
+            ),
+            service_down_action=dict(
+                required=False,
+                choices=[
+                    'none', 'reset',
+                    'drop', 'reselect'
+                    ],
+                default=None
+            ),
+            description=dict(
+                required=False,
+                default=None,
+            ),
+            host=dict(
+                required=False,
+                aliases=['address'],
+                default=None
+            ),
+            port=dict(
+                required=False,
+                default=None,
+                type='int'
+            )
+            )
+        self.f5_product_name = 'bigip'
+
+
+def main():
+    if not HAS_F5SDK:
+        raise F5ModuleError("The python f5-sdk module is required")
+
+    spec = ArgumentSpec()
+
+    client = AnsibleF5Client(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+        f5_product_name=spec.f5_product_name
+    )
+
+    try:
+        mm = ModuleManager(client)
+        results = mm.exec_module()
+        client.module.exit_json(**results)
+    except F5ModuleError as e:
+        client.module.fail_json(msg=str(e))
+
+if __name__ == '__main__':
+    main()

--- a/library/bigip_pool2.py
+++ b/library/bigip_pool2.py
@@ -28,9 +28,9 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: bigip_pool
-short_description: "Manages F5 BIG-IP LTM pools"
+short_description: Manages F5 BIG-IP LTM pools.
 description:
-  - Manages F5 BIG-IP LTM pools via iControl REST API
+  - Manages F5 BIG-IP LTM pools via iControl REST API.
 version_added: 1.2
 author:
   - Tim Rupp (@caphrim007)
@@ -40,40 +40,36 @@ notes:
   - F5 developed module 'F5-SDK' required (https://github.com/F5Networks/f5-common-python)
   - Best run as a local_action in your playbook
 requirements:
-  - bigsuds
+  - f5-sdk
 options:
   description:
     description:
       - Specifies descriptive text that identifies the pool.
-    required: false
+    required: False
     version_added: "2.3"
   state:
     description:
-      - Pool/pool member state
-    required: false
+      - Pool/pool member state.
+    required: False
     default: present
     choices:
       - present
       - absent
-    aliases: []
-  name:
+   name:
     description:
       - Pool name
-    required: true
-    default: null
-    choices: []
+    required: True
+    default: None
     aliases:
       - pool
   partition:
     description:
-      - Partition of pool/pool member
-    required: false
+      - Partition of pool/pool member.
+    required: False
     default: 'Common'
-    choices: []
-    aliases: []
   lb_method:
     description:
-      - Load balancing method
+      - Load balancing method.
     version_added: "1.3"
     required: False
     default: 'round_robin'
@@ -98,76 +94,62 @@ options:
       - ratio_session
       - ratio_least_connection_member
       - ratio_least_connection_node_address
-    aliases: []
   monitor_type:
     description:
       - Monitor rule type when monitors > 1
     version_added: "1.3"
     required: False
-    default: null
+    default: None
     choices: ['and_list', 'm_of_n']
-    aliases: []
   quorum:
     description:
-      - Monitor quorum value when monitor_type is m_of_n
+      - Monitor quorum value when C(monitor_type) is C(m_of_n).
     version_added: "1.3"
     required: False
-    default: null
-    choices: []
-    aliases: []
+    default: None
   monitors:
     description:
       - Monitor template name list. Always use the full path to the monitor.
     version_added: "1.3"
     required: False
-    default: null
-    choices: []
-    aliases: []
+    default: None
   slow_ramp_time:
     description:
       - Sets the ramp-up time (in seconds) to gradually ramp up the load on
-        newly added or freshly detected up pool members
+        newly added or freshly detected up pool members.
     version_added: "1.3"
     required: False
-    default: null
-    choices: []
-    aliases: []
+    default: None
   reselect_tries:
     description:
       - Sets the number of times the system tries to contact a pool member
-        after a passive failure
+        after a passive failure.
     version_added: "2.2"
     required: False
-    default: null
-    choices: []
-    aliases: []
+    default: None
   service_down_action:
     description:
-      - Sets the action to take when node goes down in pool
+      - Sets the action to take when node goes down in pool.
     version_added: "1.3"
     required: False
-    default: null
+    default: None
     choices:
       - none
       - reset
       - drop
       - reselect
-    aliases: []
   host:
     description:
-      - "Pool member IP"
+      - Pool member IP.
     required: False
-    default: null
-    choices: []
+    default: None
     aliases:
       - address
   port:
     description:
-      - Pool member port
+      - Pool member port.
     required: False
-    default: null
-    choices: []
-    aliases: []
+    default: None
 extends_documentation_fragment: f5
 '''
 
@@ -193,6 +175,7 @@ EXAMPLES = '''
       name: "my-pool"
       partition: "Common"
       lb_method: "round_robin"
+  delegate_to: localhost
 
 - name: Add pool member
   bigip_pool:
@@ -204,6 +187,7 @@ EXAMPLES = '''
       partition: "Common"
       host: "{{ ansible_default_ipv4["address"] }}"
       port: 80
+  delegate_to: localhost
 
 - name: Remove pool member from pool
   bigip_pool:
@@ -215,6 +199,7 @@ EXAMPLES = '''
       partition: "Common"
       host: "{{ ansible_default_ipv4["address"] }}"
       port: 80
+  delegate_to: localhost
 
 - name: Delete pool
   bigip_pool:
@@ -224,6 +209,7 @@ EXAMPLES = '''
       state: "absent"
       name: "my-pool"
       partition: "Common"
+  delegate_to: localhost
 '''
 
 RETURN = '''
@@ -236,16 +222,17 @@ from netaddr import IPAddress, AddrFormatError
 class Parameters(AnsibleF5Parameters):
 
     api_map = {
-        'loadBalancingMode': 'lb_method', 'slowRampTime': 'slow_ramp_time',
+        'loadBalancingMode': 'lb_method',
+        'slowRampTime': 'slow_ramp_time',
         'reselectTries': 'reselect_tries',
         'serviceDownAction': 'service_down_action'
-               }
+    }
 
     updatables = [
         'monitor_type', 'quorum', 'monitors', 'service_down_action',
         'description', 'lb_method', 'host', 'port', 'slow_ramp_time',
         'reselect_tries'
-                    ]
+    ]
 
     returnables = [
         'monitor_type', 'quorum', 'monitors', 'service_down_action',
@@ -306,7 +293,7 @@ class Parameters(AnsibleF5Parameters):
                     and_list.append('and')
                     and_list.append(m)
             result = ' '.join(and_list)
-        if monitor_type == 'm_of_n':
+        elif monitor_type == 'm_of_n':
             min_list = list()
             prefix = 'min' + ' ' + str(quorum) + ' ' + 'of' + ' ' + '{'
             min_list.append(prefix)
@@ -451,8 +438,9 @@ class ModuleManager(object):
 
     def update(self):
         self.have, members, poolres = self.read_current_from_device()
-        if self._member_does_not_exist(members):
-            self.create_member_on_device(poolres)
+        if not self.client.check_mode:
+            if self._member_does_not_exist(members):
+                self.create_member_on_device(poolres)
         if not self.should_update():
             return False
         if self.client.check_mode:
@@ -478,39 +466,49 @@ class ModuleManager(object):
     def create_on_device(self):
         params = self.want.api_params()
         self.client.api.tm.ltm.pools.pool.create(
-            partition=self.want.partition, **params)
+            partition=self.want.partition, **params
+        )
 
     def create_member_on_device(self, poolres):
-        poolres.members_s.members.create(name=self.want.member_name,
-                                         partition=self.want.partition)
+        poolres.members_s.members.create(
+            name=self.want.member_name,
+            partition=self.want.partition
+        )
 
     def update_on_device(self):
         params = self.want.api_params()
         result = self.client.api.tm.ltm.pools.pool.load(
-            name=self.want.name, partition=self.want.partition
+            name=self.want.name,
+            partition=self.want.partition
         )
         result.modify(**params)
 
     def exists(self):
         return self.client.api.tm.ltm.pools.pool.exists(
-            name=self.want.name, partition=self.want.partition
+            name=self.want.name,
+            partition=self.want.partition
         )
 
     def remove_from_device(self):
         result = self.client.api.tm.ltm.pools.pool.load(
-            name=self.want.name, partition=self.want.partition
+            name=self.want.name,
+            partition=self.want.partition
         )
-        member = result.members_s.members.load(name=self.want.member_name,
-                                               partition=self.want.partition)
+        member = result.members_s.members.load(
+            name=self.want.member_name,
+            partition=self.want.partition
+        )
         if member:
             member.delete()
             self.delete_node_on_device()
+
         if result:
             result.delete()
 
     def read_current_from_device(self):
         tmp_res = self.client.api.tm.ltm.pools.pool.load(
-            name=self.want.name, partition=self.want.partition
+            name=self.want.name,
+            partition=self.want.partition
         )
         members = tmp_res.members_s.get_collection()
 
@@ -519,7 +517,9 @@ class ModuleManager(object):
 
     def delete_node_on_device(self):
         node = self.client.api.tm.ltm.nodes.node.load(
-            name=self.want.host, partition=self.want.partition)
+            name=self.want.host,
+            partition=self.want.partition
+        )
         try:
             node.delete()
         except iControlUnexpectedHTTPError as e:
@@ -587,7 +587,7 @@ class ArgumentSpec(object):
                 choices=[
                     'none', 'reset',
                     'drop', 'reselect'
-                    ],
+                ],
                 default=None
             ),
             description=dict(
@@ -603,7 +603,7 @@ class ArgumentSpec(object):
                 required=False,
                 default=None,
                 type='int'
-            )
+                )
             )
         self.f5_product_name = 'bigip'
 

--- a/library/bigip_pool2.py
+++ b/library/bigip_pool2.py
@@ -295,7 +295,7 @@ class Parameters(AnsibleF5Parameters):
             result = ' '.join(and_list)
         elif monitor_type == 'm_of_n':
             min_list = list()
-            prefix = 'min' + ' ' + str(quorum) + ' ' + 'of' + ' ' + '{'
+            prefix = 'min {0} of {'.format(str(quorum))
             min_list.append(prefix)
             for m in monitors:
                 min_list.append(m)

--- a/test/integration/bigip_pool.yaml
+++ b/test/integration/bigip_pool.yaml
@@ -20,8 +20,10 @@
 #
 # Tested platforms:
 #
-#    - 12.1.1 HF1
-#
+#    - 12.1.2 Final
+#    - 12.0.0 HF1
+#    - 11.6.1 HF1
+#    - 11.5.4 HF1
 
 - name: Test the bigip_pool module
   hosts: f5-test

--- a/test/unit/bigip/fixtures/load_ltm_pool.json
+++ b/test/unit/bigip/fixtures/load_ltm_pool.json
@@ -1,0 +1,32 @@
+{
+  "kind": "tm:ltm:pool:poolstate",
+  "name": "test_pool",
+  "partition": "Common",
+  "fullPath": "/Common/test_pool",
+  "generation": 1452,
+  "selfLink": "https://localhost/mgmt/tm/ltm/pool/~Common~test_pool?ver=11.5.4",
+  "allowNat": "yes",
+  "allowSnat": "yes",
+  "description": "test",
+  "ignorePersistedWeight": "disabled",
+  "ipTosToClient": "pass-through",
+  "ipTosToServer": "pass-through",
+  "linkQosToClient": "pass-through",
+  "linkQosToServer": "pass-through",
+  "loadBalancingMode": "round-robin",
+  "minActiveMembers": 0,
+  "minUpMembers": 0,
+  "minUpMembersAction": "failover",
+  "minUpMembersChecking": "disabled",
+  "monitor": "min 1 of { /Common/http /Common/inband }",
+  "queueDepthLimit": 0,
+  "queueOnConnectionLimit": "disabled",
+  "queueTimeLimit": 0,
+  "reselectTries": 0,
+  "serviceDownAction": "reselect",
+  "slowRampTime": 10,
+  "membersReference": {
+    "link": "https://localhost/mgmt/tm/ltm/pool/~Common~test_pool/members?ver=11.5.4",
+    "isSubcollection": true
+  }
+}

--- a/test/unit/bigip/fixtures/pool_members_subcollection.json
+++ b/test/unit/bigip/fixtures/pool_members_subcollection.json
@@ -1,0 +1,21 @@
+[
+    {
+      "kind": "tm:ltm:pool:members:membersstate",
+      "name": "1.1.1.1:80",
+      "partition": "Common",
+      "fullPath": "/Common/1.1.1.1:80",
+      "generation": 1,
+      "selfLink": "https://localhost/mgmt/tm/ltm/pool/~Common~test_pool/members/~Common~1.1.1.1:80?ver=11.5.4",
+      "address": "1.1.1.1",
+      "connectionLimit": 0,
+      "dynamicRatio": 1,
+      "inheritProfile": "enabled",
+      "logging": "disabled",
+      "monitor": "default",
+      "priorityGroup": 0,
+      "rateLimit": "disabled",
+      "ratio": 1,
+      "session": "user-disabled",
+      "state": "up"
+    }
+  ]

--- a/test/unit/bigip/test_bigip_pool.py
+++ b/test/unit/bigip/test_bigip_pool.py
@@ -1,0 +1,523 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public Liccense for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils.f5_utils import (
+    AnsibleF5Client,
+    F5ModuleError
+)
+
+from library.bigip_pool2 import (
+    Parameters,
+    ModuleManager,
+    ArgumentSpec,
+)
+
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as f:
+        data = f.read()
+
+    try:
+        data = json.loads(data)
+    except:
+        pass
+
+    fixture_data[path] = data
+    return data
+
+
+class BigIpObj(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class TestParameters(unittest.TestCase):
+    def test_module_parameters(self):
+        m = ['/Common/Fake', '/Common/Fake2']
+        args = dict(
+            lb_method='obscure_hypenated_fake_method',
+            monitor_type='m_of_n',
+            monitors=m,
+            quorum=1,
+            slow_ramp_time=200,
+            reselect_tries=5,
+            service_down_action='drop',
+            host='192.168.1.1',
+            port=8080
+        )
+
+        p = Parameters(args)
+        assert p.lb_method == 'obscure-hypenated-fake-method'
+        assert p.monitor_type == 'm_of_n'
+        assert p.quorum == 1
+        assert p.monitors == m
+        assert p.monitor == 'min 1 of { /Common/Fake /Common/Fake2 }'
+        assert p.host == '192.168.1.1'
+        assert p.port == 8080
+        assert p.member_name == '192.168.1.1:8080'
+        assert p.slow_ramp_time == 200
+        assert p.reselect_tries == 5
+        assert p.service_down_action == 'drop'
+
+    def test_api_parameters(self):
+        m = ['/Common/Fake', '/Common/Fake2']
+        args = dict(
+            loadBalancingMode='obscure_hypenated_fake_method',
+            monitor_type='and_list',
+            monitors=m,
+            slowRampTime=200,
+            reselectTries=5,
+            serviceDownAction='drop'
+
+        )
+
+        p = Parameters(args)
+        assert p.lb_method == 'obscure-hypenated-fake-method'
+        assert p.monitor == '/Common/Fake and /Common/Fake2'
+        assert p.slow_ramp_time == 200
+        assert p.reselect_tries == 5
+        assert p.service_down_action == 'drop'
+
+
+@patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
+       return_value=True)
+class TestManager(unittest.TestCase):
+
+    def setUp(self):
+        self.spec = ArgumentSpec()
+        self.loaded_members = []
+        members = load_fixture('pool_members_subcollection.json')
+        for item in members:
+            self.loaded_members.append(BigIpObj(**item))
+
+    def test_create_pool(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            description='fakepool',
+            service_down_action='drop',
+            lb_method='round_robin',
+            partition='Common',
+            slow_ramp_time=10,
+            reselect_tries=1,
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['name'] == 'fake_pool'
+        assert results['description'] == 'fakepool'
+        assert results['service_down_action'] == 'drop'
+        assert results['lb_method'] == 'round-robin'
+        assert results['slow_ramp_time'] == 10
+        assert results['reselect_tries'] == 1
+
+    def test_create_pool_with_pool_member(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            partition='Common',
+            host='192.168.1.1',
+            port=8080,
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['host'] == '192.168.1.1'
+        assert results['port'] == 8080
+        assert results['member_name'] == '192.168.1.1:8080'
+
+    def test_create_pool_invalid_host(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            partition='Common',
+            host='this.will.fail',
+            port=8080,
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        msg = "'this.will.fail' is not a valid IP address"
+
+        with pytest.raises(F5ModuleError) as err:
+            mm.exec_module()
+        assert err.value.message == msg
+
+    def test_create_pool_invalid_port(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            partition='Common',
+            host='192.168.1.1',
+            port=98741,
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        msg = "The provided port '98741' must be between 0 and 65535"
+
+        with pytest.raises(F5ModuleError) as err:
+            mm.exec_module()
+        assert err.value.message == msg
+
+
+    def test_create_pool_monitor_type_missing(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            lb_method='round_robin',
+            partition='Common',
+            monitors=['/Common/tcp', '/Common/http'],
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        msg = "The 'monitor_type' parameter cannot be empty when " \
+              "'monitors' parameter is specified."
+        with pytest.raises(F5ModuleError) as err:
+            mm.exec_module()
+
+        assert err.value.message == msg
+
+    def test_create_pool_monitors_missing(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            lb_method='round_robin',
+            partition='Common',
+            monitor_type='and_list',
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        msg = "The 'monitor' parameter cannot be empty when " \
+              "'monitor_type' parameter is specified"
+        with pytest.raises(F5ModuleError) as err:
+            mm.exec_module()
+
+        assert err.value.message == msg
+
+    def test_create_pool_quorum_missing(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            lb_method='round_robin',
+            partition='Common',
+            monitor_type='m_of_n',
+            monitors=['/Common/tcp', '/Common/http'],
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        msg = "Quorum value must be specified with monitor_type 'm_of_n'."
+        with pytest.raises(F5ModuleError) as err:
+            mm.exec_module()
+
+        assert err.value.message == msg
+
+    def test_create_pool_monitor_and_list(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            partition='Common',
+            monitor_type='and_list',
+            monitors=['/Common/tcp', '/Common/http'],
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['name'] == 'fake_pool'
+        assert results['monitors'] == ['/Common/tcp', '/Common/http']
+        assert results['monitor_type'] == 'and_list'
+        assert results['monitor'] == '/Common/tcp and /Common/http'
+
+    def test_create_pool_monitor_m_of_n(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            partition='Common',
+            monitor_type='m_of_n',
+            quorum=1,
+            monitors=['/Common/tcp', '/Common/http'],
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['name'] == 'fake_pool'
+        assert results['monitors'] == ['/Common/tcp', '/Common/http']
+        assert results['monitor_type'] == 'm_of_n'
+        assert results['monitor'] == 'min 1 of { /Common/tcp /Common/http }'
+
+    def test_update_monitors(self, *args):
+        set_module_args(dict(
+            name='test_pool',
+            partition='Common',
+            monitor_type='and_list',
+            monitors=['/Common/http', '/Common/tcp'],
+            server='localhost',
+            password='password',
+            user='admin',
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+        mm = ModuleManager(client)
+
+        current = (Parameters(
+                load_fixture('load_ltm_pool.json')
+                ),
+            [],
+            {},
+            )
+
+        mm.exit_json = lambda x: False
+        mm.update_on_device = lambda: True
+        mm.exists = lambda: True
+        mm.read_current_from_device = lambda: current
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['monitors'] == ['/Common/http', '/Common/tcp']
+        assert results['monitor_type'] == 'and_list'
+        assert results['monitor'] == '/Common/http and /Common/tcp'
+
+    def test_update_pool_new_member(self, *args):
+        set_module_args(dict(
+            name='test_pool',
+            partition='Common',
+            host='192.168.1.1',
+            port=8080,
+            server='localhost',
+            password='password',
+            user='admin',
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+        mm = ModuleManager(client)
+
+        current = (Parameters(
+                load_fixture('load_ltm_pool.json')
+                ),
+                   self.loaded_members,
+                   {},
+            )
+
+        mm.exit_json = lambda x: False
+        mm.update_on_device = lambda: True
+        mm.exists = lambda: True
+        mm.read_current_from_device = lambda: current
+        mm.create_member_on_device = lambda x: True
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['host'] == '192.168.1.1'
+        assert results['port'] == 8080
+
+    def test_update_pool_member_exists(self, *args):
+        set_module_args(dict(
+            name='test_pool',
+            partition='Common',
+            host='1.1.1.1',
+            port=80,
+            server='localhost',
+            password='password',
+            user='admin',
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+        mm = ModuleManager(client)
+
+        current = (Parameters(
+                load_fixture('load_ltm_pool.json')
+                ),
+                   self.loaded_members,
+                   {},
+            )
+
+        mm.exit_json = lambda x: False
+        mm.update_on_device = lambda: True
+        mm.exists = lambda: True
+        mm.read_current_from_device = lambda: current
+        mm.create_member_on_device = lambda x: True
+
+        results = mm.exec_module()
+
+        assert results['changed'] is False


### PR DESCRIPTION
Problem:

	bigip_pool lib needed an overhaul to use REST instead of SOAP

Analysis:

	Reworked bigip_pool lib with the corresponding tests and
	docs, to user REST and be in line with the new convention.
	Created bigip_pool2.py so that the library
	can gracefully replace bigip_pool.

Tests:
       Unit
       Functional