### PR TITLE
Fixes #145

### DIFF
--- a/library/bigip_pool2.py
+++ b/library/bigip_pool2.py
@@ -109,7 +109,8 @@ options:
     default: None
   monitors:
     description:
-      - Monitor template name list. Always use the full path to the monitor.
+      - Monitor template name list. If full path is not provided,
+        it will be appended by the set partition name.
     version_added: "1.3"
     required: False
     default: None
@@ -237,7 +238,8 @@ class Parameters(AnsibleF5Parameters):
     returnables = [
         'monitor_type', 'quorum', 'monitors', 'service_down_action',
         'description', 'lb_method', 'host', 'port', 'monitor',
-        'slow_ramp_time', 'reselect_tries', 'name', 'member_name'
+        'slow_ramp_time', 'reselect_tries', 'name', 'member_name',
+        'partition'
     ]
 
     api_attributes = [
@@ -255,16 +257,27 @@ class Parameters(AnsibleF5Parameters):
 
     @property
     def monitors(self):
-        monitors = self._values['monitors']
+        part = '/' + self.partition
+        monitors = list()
+        monitor_list = self._values['monitors']
         monitor_type = self._values['monitor_type']
         error1 = "The 'monitor_type' parameter cannot be empty when " \
                  "'monitors' parameter is specified."
         error2 = "The 'monitor' parameter cannot be empty when " \
                  "'monitor_type' parameter is specified"
-        if monitors is not None and monitor_type is None:
+        if monitor_list is not None and monitor_type is None:
             raise F5ModuleError(error1)
-        if monitors is None and monitor_type is not None:
+        elif monitor_list is None and monitor_type is not None:
             raise F5ModuleError(error2)
+        elif monitor_list is None:
+            return None
+
+        for m in monitor_list:
+            if not m.startswith(part):
+                m = '/{0}/{1}'.format(self.partition, m)
+
+            monitors.append(m)
+
         return monitors
 
     @property

--- a/library/bigip_pool2.py
+++ b/library/bigip_pool2.py
@@ -295,7 +295,7 @@ class Parameters(AnsibleF5Parameters):
             result = ' '.join(and_list)
         elif monitor_type == 'm_of_n':
             min_list = list()
-            prefix = 'min {0} of {'.format(str(quorum))
+            prefix = 'min {0} of {{'.format(str(quorum))
             min_list.append(prefix)
             for m in monitors:
                 min_list.append(m)

--- a/test/unit/bigip/test_bigip_pool.py
+++ b/test/unit/bigip/test_bigip_pool.py
@@ -256,7 +256,6 @@ class TestManager(unittest.TestCase):
             mm.exec_module()
         assert err.value.message == msg
 
-
     def test_create_pool_monitor_type_missing(self, *args):
         set_module_args(dict(
             pool='fake_pool',
@@ -521,3 +520,127 @@ class TestManager(unittest.TestCase):
         results = mm.exec_module()
 
         assert results['changed'] is False
+
+    def test_create_pool_monitor_and_list_no_partition(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            monitor_type='and_list',
+            monitors=['tcp', 'http'],
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['name'] == 'fake_pool'
+        assert results['monitors'] == ['/Common/tcp', '/Common/http']
+        assert results['monitor_type'] == 'and_list'
+        assert results['monitor'] == '/Common/tcp and /Common/http'
+
+    def test_create_pool_monitor_m_of_n_no_partition(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            monitor_type='m_of_n',
+            quorum=1,
+            monitors=['tcp', 'http'],
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['name'] == 'fake_pool'
+        assert results['monitors'] == ['/Common/tcp', '/Common/http']
+        assert results['monitor_type'] == 'm_of_n'
+        assert results['monitor'] == 'min 1 of { /Common/tcp /Common/http }'
+
+    def test_create_pool_monitor_and_list_custom_partition(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            partition='Testing',
+            monitor_type='and_list',
+            monitors=['tcp', 'http'],
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['name'] == 'fake_pool'
+        assert results['monitors'] == ['/Testing/tcp', '/Testing/http']
+        assert results['monitor_type'] == 'and_list'
+        assert results['monitor'] == '/Testing/tcp and /Testing/http'
+
+    def test_create_pool_monitor_m_of_n_custom_partition(self, *args):
+        set_module_args(dict(
+            pool='fake_pool',
+            partition='Testing',
+            monitor_type='m_of_n',
+            quorum=1,
+            monitors=['tcp', 'http'],
+            server='localhost',
+            password='password',
+            user='admin'
+
+        ))
+
+        client = AnsibleF5Client(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            f5_product_name=self.spec.f5_product_name
+        )
+
+        mm = ModuleManager(client)
+        mm.exit_json = lambda x: False
+        mm.create_on_device = lambda: True
+        mm.exists = lambda: False
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['name'] == 'fake_pool'
+        assert results['monitors'] == ['/Testing/tcp', '/Testing/http']
+        assert results['monitor_type'] == 'm_of_n'
+        assert results['monitor'] == 'min 1 of { /Testing/tcp /Testing/http }'


### PR DESCRIPTION
Problem:

Not escaped '{' in the format string has caused ValueError exception. Full path to monitor was required to be provided.

Analysis:

Escaped '{' in the format string, all tests pass again. The full path to monitor is now being prepended automatically with the declared partition. 'Common' by default

Tests:
       Unit
       Functional