### PR TITLE
Update bigip_virtual_server2.py

### DIFF
--- a/library/bigip_virtual_server2.py
+++ b/library/bigip_virtual_server2.py
@@ -520,8 +520,8 @@ class ModuleManager(object):
 
     def exists(self):
         return self.client.api.tm.ltm.virtuals.virtual.exists(
-            name=self.have.name,
-            partition=self.have.partition
+            name=self.want.name,
+            partition=self.want.partition
         )
 
     def update(self):


### PR DESCRIPTION
When trying to ensure a vServer is present, the self function is trying to validate existence of virtual server with the arguments self.have which fails.  In tracing the error, it seems the self.want would be the appropriate arguments to pass to check for the existence of the desired vServer.  I've tested this myself and it appears to be working now.