### PR TITLE
force-full-load-push and Not All Devices Synced state

### DIFF
--- a/library/bigip_configsync_actions.py
+++ b/library/bigip_configsync_actions.py
@@ -149,6 +149,13 @@ class Parameters(AnsibleF5Parameters):
         return result
 
     @property
+    def force_full_push(self):
+        if self.overwrite_config:
+            return 'force-full-load-push'
+        else:
+            return ''
+
+    @property
     def overwrite_config(self):
         result = self._cast_to_bool(self._values['overwrite_config'])
         return result
@@ -228,9 +235,10 @@ class ModuleManager(object):
         self._wait_for_sync()
 
     def execute_on_device(self):
-        sync_cmd = 'config-sync {0} {1}'.format(
+        sync_cmd = 'config-sync {0} {1} {2}'.format(
             self.want.direction,
-            self.want.device_group
+            self.want.device_group,
+            self.want.force_full_push
         )
         self.client.api.tm.cm.exec_cmd(
             'run',

--- a/library/bigip_configsync_actions.py
+++ b/library/bigip_configsync_actions.py
@@ -260,7 +260,11 @@ class ModuleManager(object):
             #     done yet. You _must_ `sync_device_to_group` in this
             #     case.
             #
-            if status in ['Changes Pending', 'Awaiting Initial Sync']:
+            # Not All Devices Synced:
+            #     A device group will go into this state immediately
+            #     after starting the sync and stay until all devices finish.
+            #
+            if status in ['Changes Pending', 'Awaiting Initial Sync', 'Not All Devices Synced']:
                 pass
             elif status == 'In Sync':
                 return


### PR DESCRIPTION
The overwrite_config parameter should add the force-full-load-push argument to the sync command unless I'm misunderstanding its purpose.

Need to wait for "Not All Devices Synced" state as well since the device group will typically go into this state immediately after starting the sync.