### PR TITLE
Update bigip_selfip.py

### DIFF
--- a/library/bigip_selfip.py
+++ b/library/bigip_selfip.py
@@ -593,7 +593,7 @@ class BigIpSelfIp(object):
             )
 
         if traffic_group is None:
-            params['trafficGroup'] = "/%s/%s" % (partition, DEFAULT_TG)
+            params['trafficGroup'] = "/Common/%s" % (DEFAULT_TG)
         else:
             traffic_group = "/%s/%s" % (partition, traffic_group)
             if traffic_group in self.traffic_groups():


### PR DESCRIPTION
Default traffic group should probably come from /Common - there does not appear to be any way to explicitly call traffic groups from /Common if you are in a different partition.