### PR TITLE
netaddr mistakenly given IP address including route domain, e.g. "1.2…

### DIFF
--- a/library/bigip_virtual_server.py
+++ b/library/bigip_virtual_server.py
@@ -229,7 +229,7 @@ class Parameters(AnsibleF5Parameters):
             return None
         destination = self._values['destination']
         try:
-            netaddr.IPAddress(destination)
+            netaddr.IPAddress(destination.split("%")[0])
         except netaddr.core.AddrFormatError:
             raise F5ModuleError(
                 "The provided destination is not a valid IP address"


### PR DESCRIPTION
….3.4%0"

When checking for a valid destination address on a virtual server, netaddr always fails because it is given an address in the format of "1.2.3.4%0" where there route domain is being included.