### PR TITLE
Add ability to assign trunks to vlans

### DIFF
--- a/library/bigip_provision.py
+++ b/library/bigip_provision.py
@@ -51,6 +51,7 @@ options:
       - pem
       - sam
       - swg
+      - vcmp
   level:
     description:
       - Sets the provisioning level for the requested modules. Changing the
@@ -298,7 +299,7 @@ class ArgumentSpec(object):
                 choices=[
                     'afm', 'am', 'sam', 'asm', 'avr', 'fps',
                     'gtm', 'lc', 'ltm', 'pem', 'swg', 'ilx',
-                    'apm'
+                    'apm', 'vcmp'
                 ]
             ),
             level=dict(

--- a/library/bigip_vlan.py
+++ b/library/bigip_vlan.py
@@ -246,6 +246,7 @@ class Parameters(AnsibleF5Parameters):
 
     def _get_interfaces_from_device(self):
         lst = self.client.api.tm.net.interfaces.get_collection()
+        lst.append(self.client.api.tm.net.trunks.get_collection())
         return lst
 
     def _parse_return_ifcs(self):


### PR DESCRIPTION
This adds trunks to the list of interfaces that can be assigned to a VLAN