### PR TITLE
Formatting of asm_policy and command modules

### DIFF
--- a/test/integration/bigip_asm_policy.yaml
+++ b/test/integration/bigip_asm_policy.yaml
@@ -50,11 +50,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_asm_policy
+    - bigip_asm_policy

--- a/test/integration/bigip_command.yaml
+++ b/test/integration/bigip_command.yaml
@@ -50,11 +50,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_command
+    - bigip_command

--- a/test/integration/targets/bigip_asm_policy/tasks/issue-00406.yaml
+++ b/test/integration/targets/bigip_asm_policy/tasks/issue-00406.yaml
@@ -305,25 +305,6 @@
     that:
       - not result|changed
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 - name: Issue 00406 - Create ASM policy, compact XML file
   bigip_asm_policy:
     name: "{{ policy_4 }}"
@@ -660,12 +641,6 @@
       - not result|changed
   when: system_info.product_information.product_version >= "13.0.0"
 
-
-
-
-
-
-
 - name: Issue 00406 - Import ASM policy from template
   bigip_asm_policy:
     name: "{{ policy_7 }}"
@@ -713,12 +688,6 @@
   assert:
     that:
       - not result|changed
-
-
-
-
-
-
 
 - name: Issue 00406 - Remove partition
   bigip_partition:

--- a/test/integration/targets/bigip_command/tasks/main.yaml
+++ b/test/integration/targets/bigip_command/tasks/main.yaml
@@ -2,87 +2,87 @@
 
 - name: Run single command
   bigip_command:
-      commands:
-          - "tmsh show sys version"
+    commands:
+      - "tmsh show sys version"
   register: result
 
 - name: Assert Run single command
   assert:
-      that:
-          - result.stdout_lines|length == 1
+    that:
+      - result.stdout_lines|length == 1
 
 - name: Run multiple commands
   bigip_command:
-      commands:
-          - "tmsh show sys clock"
-          - "tmsh list auth"
+    commands:
+      - "tmsh show sys clock"
+      - "tmsh list auth"
   register: result
 
 - name: Assert Run multiple commands
   assert:
-      that:
-          - result.stdout_lines|length == 2
+    that:
+      - result.stdout_lines|length == 2
 
 - name: Run command missing tmsh
   bigip_command:
-      commands:
-          - "show sys clock"
+    commands:
+      - "show sys clock"
   register: result
 
 - name: Assert Run command missing tmsh
   assert:
-      that:
-          - result.stdout_lines|length == 1
+    that:
+      - result.stdout_lines|length == 1
 
 - name: Run multiple commands, one missing tmsh
   bigip_command:
-      commands:
-          - "tmsh show sys clock"
-          - "list auth"
+    commands:
+      - "tmsh show sys clock"
+      - "list auth"
   register: result
 
 - name: Assert Run multiple commands, one missing tmsh
   assert:
-      that:
-          - result.stdout_lines|length == 2
+    that:
+      - result.stdout_lines|length == 2
 
 - name: Wait for something
   bigip_command:
-      commands:
-          - "tmsh show sys clock"
-      wait_for:
-          - result[0] contains Sys::Clock
+    commands:
+      - "tmsh show sys clock"
+    wait_for:
+      - result[0] contains Sys::Clock
   register: result
 
 - name: Assert Wait for something
   assert:
-      that:
-          - result.stdout_lines|length == 1
+    that:
+      - result.stdout_lines|length == 1
 
 - name: Assert Run modify commands with a show command
   assert:
-      that:
-          - "'Sys::Clock' in result.stdout_lines[0][1]"
-          - result.stdout_lines|length == 1
+    that:
+      - "'Sys::Clock' in result.stdout_lines[0][1]"
+      - result.stdout_lines|length == 1
 
 - name: Run modify commands
   bigip_command:
-      commands:
-          - "tmsh modify sys db setup.run value true"
-          - tmsh modify sys db setup.run value false
+    commands:
+      - "tmsh modify sys db setup.run value true"
+      - tmsh modify sys db setup.run value false
   register: result
 
 - name: Assert Run modify commands
   assert:
-      that:
-          - result.stdout_lines|length == 0
+    that:
+      - result.stdout_lines|length == 0
 
 - name: Run modify commands with a show command
   bigip_command:
-      commands:
-          - "tmsh modify sys db setup.run value true"
-          - tmsh modify sys db setup.run value false
-          - "tmsh show sys clock"
+    commands:
+      - "tmsh modify sys db setup.run value true"
+      - tmsh modify sys db setup.run value false
+      - "tmsh show sys clock"
   register: result
 
 - import_tasks: issue-00381.yaml


### PR DESCRIPTION
Remove extra whitespace lines between tasks.
Use 2-space instead of 4-space indents in yaml files.