### PR TITLE
Bugfix.formatting and standards

### DIFF
--- a/test/integration/bigip_config.yaml
+++ b/test/integration/bigip_config.yaml
@@ -50,11 +50,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_config
+    - bigip_config

--- a/test/integration/bigip_configsync_action.yaml
+++ b/test/integration/bigip_configsync_action.yaml
@@ -42,13 +42,13 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   tasks:
-      - name: Include test role
-        include_role:
-            name: bigip_configsync_actions
+    - name: Include test role
+      include_role:
+        name: bigip_configsync_actions

--- a/test/integration/bigip_device_connectivity.yaml
+++ b/test/integration/bigip_device_connectivity.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_device_connectivity
+    - bigip_device_connectivity

--- a/test/integration/bigip_device_dns.yaml
+++ b/test/integration/bigip_device_dns.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_device_dns
+    - bigip_device_dns

--- a/test/integration/targets/bigip_config/tasks/main.yaml
+++ b/test/integration/targets/bigip_config/tasks/main.yaml
@@ -6,33 +6,33 @@
 
 - name: Save the running BIG-IP configuration to disk
   bigip_config:
-      save: True
+    save: True
   register: result
 
 - name: Reset device
   bigip_config:
-      reset: True
-      save: True
+    reset: True
+    save: True
   register: result
 
 - name: Reset device, load new running configuration, save it
   bigip_config:
-      reset: True
-      save: True
-      merge_content: "{{ lookup('file', 'bigip.scf') }}"
-      verify: False
+    reset: True
+    save: True
+    merge_content: "{{ lookup('file', 'bigip.scf') }}"
+    verify: False
   register: result
 
 - name: Ensure virtual server description is same as in SCF file
   bigip_virtual_server:
-      description: "my description"
-      destination: "10.10.10.10"
-      name: "bar10"
-      port: "80"
-      state: "present"
+    description: "my description"
+    destination: "10.10.10.10"
+    name: "bar10"
+    port: "80"
+    state: "present"
   register: result
 
 - name: Assert Ensure virtual server description is same as in SCF file
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_configsync_action/tasks/main.yaml
+++ b/test/integration/targets/bigip_configsync_action/tasks/main.yaml
@@ -3,14 +3,14 @@
 # In this task list, the 0th item is the Active unit and the 1st item is the
 # standby unit.
 
-- include: setup.yaml
+- import_tasks: setup.yaml
   when: ansible_play_batch[0] == inventory_hostname
 
-- include: test-device-to-group.yaml
+- import_tasks: test-device-to-group.yaml
   when: ansible_play_batch[0] == inventory_hostname
 
-- include: test-pull-recent-device.yaml
+- import_tasks: test-pull-recent-device.yaml
   when: ansible_play_batch[1] == inventory_hostname
 
-- include: teardown.yaml
+- import_tasks: teardown.yaml
   when: ansible_play_batch[0] == inventory_hostname

--- a/test/integration/targets/bigip_configsync_action/tasks/setup.yaml
+++ b/test/integration/targets/bigip_configsync_action/tasks/setup.yaml
@@ -2,12 +2,12 @@
 
 - name: Create pool
   bigip_pool:
-      lb_method: "round-robin"
-      name: "cs1.pool"
-      state: "present"
+    lb_method: "round-robin"
+    name: "cs1.pool"
+    state: "present"
   register: result
 
 - name: Assert Create pool
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed

--- a/test/integration/targets/bigip_configsync_action/tasks/teardown.yaml
+++ b/test/integration/targets/bigip_configsync_action/tasks/teardown.yaml
@@ -2,20 +2,20 @@
 
 - name: Delete pool - First device
   bigip_pool:
-      name: "{{ item }}"
-      state: "absent"
-  with_items:
-      - "cs1.pool"
-      - "cs2.pool"
+    name: "{{ item }}"
+    state: "absent"
+  loop:
+    - "cs1.pool"
+    - "cs2.pool"
   register: result
 
 - name: Assert Delete pool
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Sync configuration from device to group
   bigip_configsync_actions:
-      device_group: "{{ device_group }}"
-      sync_device_to_group: yes
+    device_group: "{{ device_group }}"
+    sync_device_to_group: yes
   register: result

--- a/test/integration/targets/bigip_configsync_action/tasks/test-device-to-group.yaml
+++ b/test/integration/targets/bigip_configsync_action/tasks/test-device-to-group.yaml
@@ -2,22 +2,22 @@
 
 - name: Sync configuration from device to group
   bigip_configsync_actions:
-      device_group: "{{ device_group }}"
-      sync_device_to_group: yes
+    device_group: "{{ device_group }}"
+    sync_device_to_group: yes
   register: result
 
 - name: Sync configuration from device to group
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Sync configuration from device to group - Idempotent check
   bigip_configsync_actions:
-      device_group: "{{ device_group }}"
-      sync_device_to_group: yes
+    device_group: "{{ device_group }}"
+    sync_device_to_group: yes
   register: result
 
 - name: Sync configuration from device to group - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_configsync_action/tasks/test-pull-recent-device.yaml
+++ b/test/integration/targets/bigip_configsync_action/tasks/test-pull-recent-device.yaml
@@ -2,47 +2,47 @@
 
 - name: Create another pool - First device
   bigip_pool:
-      server: "{{ hostvars['bigip1']['ansible_host'] }}"
-      lb_method: "round_robin"
-      name: "cs2.pool"
-      state: "present"
+    server: "{{ hostvars['bigip1']['ansible_host'] }}"
+    lb_method: "round_robin"
+    name: "cs2.pool"
+    state: "present"
   register: result
 
 - name: Assert Create another pool - First device
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Sync configuration from most recent - Second device
   bigip_configsync_actions:
-      device_group: "{{ device_group }}"
-      sync_most_recent_to_device: yes
+    device_group: "{{ device_group }}"
+    sync_most_recent_to_device: yes
   register: result
 
 - name: Assert Sync configuration from most recent - Second device
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Sync configuration from most recent - Second device - Idempotent check
   bigip_configsync_actions:
-      device_group: "{{ device_group }}"
-      sync_most_recent_to_device: yes
+    device_group: "{{ device_group }}"
+    sync_most_recent_to_device: yes
   register: result
 
 - name: Assert Sync configuration from most recent - Second device - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Create another pool again - Second device - ensure it was created in previous sync
   bigip_pool:
-      lb_method: "round_robin"
-      name: "cs2.pool"
-      state: "present"
+    lb_method: "round_robin"
+    name: "cs2.pool"
+    state: "present"
   register: result
 
 - name: Assert Create another pool again - Second device - ensure it was deleted in previous sync
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_device_dns/tasks/main.yaml
+++ b/test/integration/targets/bigip_device_dns/tasks/main.yaml
@@ -2,292 +2,292 @@
 
 - name: Enable cache
   bigip_device_dns:
-      cache: "enable"
+    cache: "enable"
   register: result
 
 - name: Assert Enable cache
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Enable cache - Idempotent check
   bigip_device_dns:
-      cache: "enable"
+    cache: "enable"
   register: result
 
 - name: Assert Enable cache - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Disable cache
   bigip_device_dns:
-      cache: "disable"
+    cache: "disable"
   register: result
 
 - name: Assert Disable cache
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Disable cache - Idempotent check
   bigip_device_dns:
-      cache: "disable"
+    cache: "disable"
   register: result
 
 - name: Assert Disable cache - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Enable cache - Incorrect value
   bigip_device_dns:
-      cache: "disabled"
+    cache: "disabled"
   register: result
   ignore_errors: true
 
 - name: Assert Enable cache - Incorrect value
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set IP version 6
   bigip_device_dns:
-      ip_version: "6"
+    ip_version: "6"
   register: result
 
 - name: Assert Set IP version 6
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set IP version 6 - Idempotent check
   bigip_device_dns:
-      ip_version: "6"
+    ip_version: "6"
   register: result
 
 - name: Assert Set IP version 6 - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set IP version 4
   bigip_device_dns:
-      ip_version: "4"
+    ip_version: "4"
   register: result
 
 - name: Assert Set IP version 4
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set IP version 4 - Idempotent check
   bigip_device_dns:
-      ip_version: "4"
+    ip_version: "4"
   register: result
 
 - name: Assert Set IP version 4 - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set Unknown IP version
   bigip_device_dns:
-      ip_version: "10"
+    ip_version: "10"
   register: result
   ignore_errors: true
 
 - name: Assert Set Unknown IP version
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 # Sending a string to a parameter that is expected to be a list will
 # cast the string to a list automatically, making this method valid
 - name: Set a nameserver
   bigip_device_dns:
-      name_servers: "10.10.10.10"
+    name_servers: "10.10.10.10"
   register: result
   ignore_errors: true
 
 - name: Assert Set a nameserver
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set a nameserver
   bigip_device_dns:
-      name_servers:
-          - "12.12.12.12"
+    name_servers:
+      - "12.12.12.12"
   register: result
 
 - name: Assert Set a nameserver
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set a nameserver - Idempotent check
   bigip_device_dns:
-      name_servers:
-          - "12.12.12.12"
+    name_servers:
+      - "12.12.12.12"
   register: result
 
 - name: Assert Set a nameserver - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set an empty nameserver
   bigip_device_dns:
-      name_servers:
-          - ""
+    name_servers:
+      - ""
   register: result
 
 - name: Assert Set an empty nameserver
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set an empty nameserver - Idempotent check
   bigip_device_dns:
-      name_servers:
-          - ""
+    name_servers:
+      - ""
   register: result
 
 - name: Assert Set an empty nameserver - Idempotent check
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set a list of name servers
   bigip_device_dns:
-      name_servers:
-          - "10.10.10.10"
-          - "11.11.11.11"
-          - "12.12.12.12"
+    name_servers:
+      - "10.10.10.10"
+      - "11.11.11.11"
+      - "12.12.12.12"
   register: result
 
 - name: Assert Set a list of name servers
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set a list of name servers - Idempotent check
   bigip_device_dns:
-      name_servers:
-          - "10.10.10.10"
-          - "11.11.11.11"
-          - "12.12.12.12"
+    name_servers:
+      - "10.10.10.10"
+      - "11.11.11.11"
+      - "12.12.12.12"
   register: result
 
 - name: Assert Set a list of name servers - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Absent a name server
   bigip_device_dns:
-      name_servers:
-          - "10.10.10.10"
-      state: "absent"
+    name_servers:
+      - "10.10.10.10"
+    state: "absent"
   register: result
 
 - name: Assert Absent a name server
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Absent a name server - Idempotent check
   bigip_device_dns:
-      name_servers:
-          - "10.10.10.10"
-      state: "absent"
+    name_servers:
+      - "10.10.10.10"
+    state: "absent"
   register: result
 
 - name: Assert Absent a name server - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set a search domain
   bigip_device_dns:
-      search:
-         - "foo.com"
+    search:
+      - "foo.com"
   register: result
 
 - name: Assert Set a search domain
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set a search domain - Idempotent check
   bigip_device_dns:
-      search:
-          - "foo.com"
+    search:
+      - "foo.com"
   register: result
 
 - name: Assert Set a search domain - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set an empty search domain
   bigip_device_dns:
-      search:
-          - ""
+    search:
+      - ""
   register: result
 
 - name: Assert Set an empty search domain
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set a list of search domains
   bigip_device_dns:
-      search:
-          - "alice.com"
-          - "bob.org"
-          - "carol.edu"
+    search:
+      - "alice.com"
+      - "bob.org"
+      - "carol.edu"
   register: result
 
 - name: Assert Set a list of search domains
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set a list of search domains - Idempotent check
   bigip_device_dns:
-      search:
-          - "alice.com"
-          - "bob.org"
-          - "carol.edu"
+    search:
+      - "alice.com"
+      - "bob.org"
+      - "carol.edu"
   register: result
 
 - name: Assert Set a list of search domains - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Absent a search domain
   bigip_device_dns:
-      search:
-          - "alice.com"
-      state: "absent"
+    search:
+      - "alice.com"
+    state: "absent"
   register: result
 
 - name: Assert Absent a search domain
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Absent a search domain - Idempotent check
   bigip_device_dns:
-      search:
-          - "alice.com"
-      state: "absent"
+    search:
+      - "alice.com"
+    state: "absent"
   register: result
 
 - name: Assert Absent a search domain - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed


### PR DESCRIPTION
Formatting and standards updates to config, configsync_action, device_connectivity, and device_dns modules.

- Decreased indents from 4 to 2 spaces
- Replaced '- include: *.yaml' with '-import_tasks: *.yaml'
- Replaced 'with_items:' with 'loop:'