### PR TITLE
Updated 4-space indents to 2-space indents.

### DIFF
--- a/test/integration/bigip_device_trust.yaml
+++ b/test/integration/bigip_device_trust.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_device_trust
+    - bigip_device_trust

--- a/test/integration/bigip_dns_record.yaml
+++ b/test/integration/bigip_dns_record.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_dns_record
+    - bigip_dns_record

--- a/test/integration/bigip_dns_record_facts.yaml
+++ b/test/integration/bigip_dns_record_facts.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_dns_record_facts
+    - bigip_dns_record_facts

--- a/test/integration/bigip_dns_zone.yaml
+++ b/test/integration/bigip_dns_zone.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_dns_zone
+    - bigip_dns_zone

--- a/test/integration/bigip_drop_connection.yaml
+++ b/test/integration/bigip_drop_connection.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_drop_connection
+    - bigip_drop_connection

--- a/test/integration/targets/bigip_device_trust/tasks/main.yaml
+++ b/test/integration/targets/bigip_device_trust/tasks/main.yaml
@@ -2,26 +2,26 @@
 
 - name: Trust remote peer device
   bigip_device_trust:
-      peer_server: "{{ hostvars[groups['f5-test'][1]].ansible_host }}"
-      peer_user: "admin"
-      peer_password: "admin"
-      peer_hostname: "foo.example.com"
+    peer_server: "{{ hostvars[groups['f5-test'][1]].ansible_host }}"
+    peer_user: "admin"
+    peer_password: "admin"
+    peer_hostname: "foo.example.com"
   register: result
 
 - name: Assert Trust remote peer device
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Trust remote peer device - Idempotent check
   bigip_device_trust:
-      peer_server: "{{ hostvars[groups['f5-test'][1]].ansible_host }}"
-      peer_user: "admin"
-      peer_password: "admin"
-      peer_hostname: "foo.example.com"
+    peer_server: "{{ hostvars[groups['f5-test'][1]].ansible_host }}"
+    peer_user: "admin"
+    peer_password: "admin"
+    peer_hostname: "foo.example.com"
   register: result
 
 - name: Assert Trust remote peer device - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_dns_zone/tasks/main.yaml
+++ b/test/integration/targets/bigip_dns_zone/tasks/main.yaml
@@ -1,7 +1,7 @@
 - name: Create a new zone on the BIG-IP
   bigip_dns_zone:
-      name: "my_datacenter"
-      contact: "admin@root.local"
-      location: "New York"
-      description: "The New York data center"
-      state: "present"
+    name: "my_datacenter"
+    contact: "admin@root.local"
+    location: "New York"
+    description: "The New York data center"
+    state: "present"


### PR DESCRIPTION
Updated device_trust, dns_record, dns_record_facts, dns_zone, and drop_connection modules to consistently use 2-space indents.