### PR TITLE
More standards and formatting updates in gtm modules

### DIFF
--- a/test/integration/bigip_gtm_server.yaml
+++ b/test/integration/bigip_gtm_server.yaml
@@ -39,11 +39,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_gtm_server
+    - bigip_gtm_server

--- a/test/integration/bigip_gtm_virtual_server.yaml
+++ b/test/integration/bigip_gtm_virtual_server.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_gtm_virtual_server
+    - bigip_gtm_virtual_server

--- a/test/integration/bigip_gtm_wide_ip.yaml
+++ b/test/integration/bigip_gtm_wide_ip.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_gtm_wide_ip
+    - bigip_gtm_wide_ip

--- a/test/integration/targets/bigip_gtm_server/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_server/tasks/main.yaml
@@ -2,140 +2,140 @@
 
 - name: Create datacenter
   bigip_gtm_datacenter:
-      name: "{{ dc_name1 }}"
+    name: "{{ dc_name1 }}"
 
 - name: Create second datacenter
   bigip_gtm_datacenter:
-      name: "{{ dc_name2 }}"
+    name: "{{ dc_name2 }}"
 
 - name: Create GTM server
   bigip_gtm_server:
-      name: "{{ server_name }}"
-      devices:
-          - name: "foo"
-            address: "1.1.1.1"
-            translation: "2.2.2.2"
-      datacenter: "{{ dc_name1 }}"
-      state: "present"
+    name: "{{ server_name }}"
+    devices:
+      - name: "foo"
+        address: "1.1.1.1"
+        translation: "2.2.2.2"
+    datacenter: "{{ dc_name1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create GTM server
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create GTM server - Idempotent check
   bigip_gtm_server:
-      name: "{{ server_name }}"
-      devices:
-          - name: "foo"
-            address: "1.1.1.1"
-            translation: "2.2.2.2"
-      datacenter: "{{ dc_name1 }}"
-      state: "present"
+    name: "{{ server_name }}"
+    devices:
+      - name: "foo"
+        address: "1.1.1.1"
+        translation: "2.2.2.2"
+    datacenter: "{{ dc_name1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create GTM server - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Update device using single address
   bigip_gtm_server:
-      name: "{{ server_name }}"
-      devices:
-          - name: "foo"
-            address: "2.2.2.2"
-            translation: "1.1.1.1"
-      datacenter: "{{ dc_name1 }}"
-      state: "present"
+    name: "{{ server_name }}"
+    devices:
+      - name: "foo"
+        address: "2.2.2.2"
+        translation: "1.1.1.1"
+    datacenter: "{{ dc_name1 }}"
+    state: "present"
   register: result
 
 - name: Assert Update device using single address
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Update device using single address - Idempotent check
   bigip_gtm_server:
-      name: "{{ server_name }}"
-      devices:
-          - name: "foo"
-            address: "2.2.2.2"
-            translation: "1.1.1.1"
-      datacenter: "{{ dc_name1 }}"
-      state: "present"
+    name: "{{ server_name }}"
+    devices:
+      - name: "foo"
+        address: "2.2.2.2"
+        translation: "1.1.1.1"
+    datacenter: "{{ dc_name1 }}"
+    state: "present"
   register: result
 
 - name: Assert Update device using single address - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Update device using multiple addresses
   bigip_gtm_server:
-      name: "{{ server_name }}"
-      devices:
-          - name: "foo"
-            addresses:
-              - address: "4.4.4.1"
-                translation: "192.168.14.10"
-              - address: "4.4.4.2"
+    name: "{{ server_name }}"
+    devices:
+      - name: "foo"
+        addresses:
+          - address: "4.4.4.1"
+            translation: "192.168.14.10"
+          - address: "4.4.4.2"
             translation: "1.1.1.1"
-      datacenter: "{{ dc_name1 }}"
-      state: "present"
+    datacenter: "{{ dc_name1 }}"
+    state: "present"
   register: result
 
 - name: Assert Update device using multiple addresses
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Update device using multiple addresses - Idempotent check
   bigip_gtm_server:
-      name: "{{ server_name }}"
-      devices:
-          - name: "foo"
-            addresses:
-              - address: "4.4.4.1"
-                translation: "192.168.14.10"
-              - address: "4.4.4.2"
+    name: "{{ server_name }}"
+    devices:
+      - name: "foo"
+        addresses:
+          - address: "4.4.4.1"
+            translation: "192.168.14.10"
+          - address: "4.4.4.2"
             translation: "1.1.1.1"
-      datacenter: "{{ dc_name1 }}"
-      state: "present"
+    datacenter: "{{ dc_name1 }}"
+    state: "present"
   register: result
 
 - name: Assert Update device using multiple addresses - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove GTM server
   bigip_gtm_server:
-      name: "{{ server_name }}"
-      state: "absent"
+    name: "{{ server_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove GTM server
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove GTM server - Idempotent check
   bigip_gtm_server:
-      name: "{{ server_name }}"
-      state: "absent"
+    name: "{{ server_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove GTM server - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove datacenters
   bigip_gtm_datacenter:
-      name: "{{ item }}"
-      state: "absent"
-  with_items:
-      - "{{ dc_name1 }}"
-      - "{{ dc_name2 }}"
+    name: "{{ item }}"
+    state: "absent"
+  loop:
+    - "{{ dc_name1 }}"
+    - "{{ dc_name2 }}"

--- a/test/integration/targets/bigip_gtm_virtual_server/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_virtual_server/tasks/main.yaml
@@ -2,35 +2,35 @@
 
 - name: Create virtual server
   bigip_gtm_virtual_server:
-      address: "10.10.10.10"
-      port: 443
-      state: "present"
-      virtual_server_name: "{{ valid_vs_name }}"
-      virtual_server_server: "{{ valid_vs_server }}"
+    address: "10.10.10.10"
+    port: 443
+    state: "present"
+    virtual_server_name: "{{ valid_vs_name }}"
+    virtual_server_server: "{{ valid_vs_server }}"
   register: result
 
 - name: Assert Create virtual server
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create virtual server - Idempotent check
   bigip_gtm_virtual_server:
-      address: "10.10.10.10"
-      port: 443
-      state: "present"
-      virtual_server_name: "{{ valid_vs_name }}"
-      virtual_server_server: "{{ valid_vs_server }}"
+    address: "10.10.10.10"
+    port: 443
+    state: "present"
+    virtual_server_name: "{{ valid_vs_name }}"
+    virtual_server_server: "{{ valid_vs_server }}"
   register: result
 
 - name: Assert Create virtual server - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Enable virtual server
   bigip_gtm_virtual_server:
-      state: "enabled"
-      virtual_server_name: "{{ valid_vs_name }}"
-      virtual_server_server: "{{ valid_vs_server }}"
+    state: "enabled"
+    virtual_server_name: "{{ valid_vs_name }}"
+    virtual_server_server: "{{ valid_vs_server }}"
   register: result

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/main.yaml
@@ -2,14 +2,14 @@
 
 - name: Ensure GTM is provisioned
   bigip_provision:
-      module: "gtm"
-      state: "present"
+    module: "gtm"
+    state: "present"
 
 - name: Collect BIG-IP facts
   bigip_facts:
-      include: "system_info"
+    include: "system_info"
   register: result
 
 - name: Test BIG-IP versions greater than 12
-  include: typed-gtm-wideip.yaml
+  import_tasks: typed-gtm-wideip.yaml
   when: system_info.product_information.product_version >= "12.0.0"

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/type-a-gtm-wideip.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/type-a-gtm-wideip.yaml
@@ -2,222 +2,222 @@
 
 - name: Create wide IP
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Disable wide IP
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "disabled"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "disabled"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Disable wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Disable wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "disabled"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "disabled"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Disable wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Enable wide IP
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "enabled"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "enabled"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Enable wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Enable wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "enabled"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "enabled"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Enable wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - ratio
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - ratio - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - topology
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - topology - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - global availability
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - global availability - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 1
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method1 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method1 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 1
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 2
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method2 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method2 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 2
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 3
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method3 }}"
-      state: "present"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method3 }}"
+    state: "present"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 3
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete wide IP
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "a"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "a"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/type-aaaa-gtm-wideip.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/type-aaaa-gtm-wideip.yaml
@@ -2,170 +2,170 @@
 
 - name: Create wide IP
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - ratio
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - ratio - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - topology
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - topology - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - global availability
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - global availability - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 1
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method1 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method1 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 1
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 2
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method2 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method2 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 2
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 3
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method3 }}"
-      state: "present"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method3 }}"
+    state: "present"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 3
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete wide IP
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "aaaa"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "aaaa"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/type-cname-gtm-wideip.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/type-cname-gtm-wideip.yaml
@@ -2,170 +2,170 @@
 
 - name: Create wide IP
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - ratio
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - ratio - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - topology
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - topology - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - global availability
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - global availability - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 1
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method1 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method1 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 1
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 2
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method2 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method2 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 2
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 3
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method3 }}"
-      state: "present"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method3 }}"
+    state: "present"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 3
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete wide IP
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "cname"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "cname"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/type-mx-gtm-wideip.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/type-mx-gtm-wideip.yaml
@@ -2,170 +2,170 @@
 
 - name: Create wide IP
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - ratio
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - ratio - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - topology
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - topology - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - global availability
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - global availability - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 1
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method1 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method1 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 1
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 2
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method2 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method2 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 2
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 3
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method3 }}"
-      state: "present"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method3 }}"
+    state: "present"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 3
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete wide IP
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "mx"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "mx"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/type-naptr-gtm-wideip.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/type-naptr-gtm-wideip.yaml
@@ -2,170 +2,170 @@
 
 - name: Create wide IP
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - ratio
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - ratio - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - topology
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - topology - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - global availability
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - global availability - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 1
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method1 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method1 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 1
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 2
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method2 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method2 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 2
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 3
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method3 }}"
-      state: "present"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method3 }}"
+    state: "present"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 3
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete wide IP
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "naptr"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "naptr"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/type-srv-gtm-wideip.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/type-srv-gtm-wideip.yaml
@@ -2,170 +2,170 @@
 
 - name: Create wide IP
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method1 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method1 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Create wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - ratio
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - ratio - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method2 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method2 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - ratio - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - topology
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - topology - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method3 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method3 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - topology - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, valid - global availability
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set wide IP LB method, valid - global availability - Idempotent check
   bigip_gtm_wide_ip:
-      lb_method: "{{ valid_lb_method4 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ valid_lb_method4 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Set wide IP LB method, valid - global availability - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 1
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method1 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method1 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 1
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 2
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method2 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method2 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 2
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set wide IP LB method, invalid 3
   bigip_gtm_wide_ip:
-      lb_method: "{{ invalid_lb_method3 }}"
-      state: "present"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    lb_method: "{{ invalid_lb_method3 }}"
+    state: "present"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
   ignore_errors: true
 
 - name: Assert Set wide IP LB method, invalid 3
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete wide IP
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete wide IP - Idempotent check
   bigip_gtm_wide_ip:
-      state: "absent"
-      type: "srv"
-      wide_ip: "{{ wide_ip1 }}"
+    state: "absent"
+    type: "srv"
+    wide_ip: "{{ wide_ip1 }}"
   register: result
 
 - name: Assert Delete wide IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/typed-gtm-wideip.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/typed-gtm-wideip.yaml
@@ -1,19 +1,19 @@
 ---
 
 - name: Test type 'A' Wide IP
-  include: type-a-gtm-wideip.yaml
+  import_tasks: type-a-gtm-wideip.yaml
 
 - name: Test type 'NAPTR' Wide IP
-  include: type-naptr-gtm-wideip.yaml
+  import_tasks: type-naptr-gtm-wideip.yaml
 
 - name: Test type 'SRV' Wide IP
-  include: type-srv-gtm-wideip.yaml
+  import_tasks: type-srv-gtm-wideip.yaml
 
 - name: Test type 'CNAME' Wide IP
-  include: type-cname-gtm-wideip.yaml
+  import_tasks: type-cname-gtm-wideip.yaml
 
 - name: Test type 'AAAA' Wide IP
-  include: type-aaaa-gtm-wideip.yaml
+  import_tasks: type-aaaa-gtm-wideip.yaml
 
 - name: Test type 'MX' Wide IP
-  include: type-mx-gtm-wideip.yaml
+  import_tasks: type-mx-gtm-wideip.yaml


### PR DESCRIPTION
Updates to gtm_server, gtm_virtual_server, and gtm_wide_ip.

Consistent 2-space indents.
Replace "include *.yaml" with "import_tasks *.yaml"
Replace "with_items:" with "loop:"