### PR TITLE
Formatting and standardization continued.  Modules iapp_service, iapp…

### DIFF
--- a/test/integration/bigip_iapp_service.yaml
+++ b/test/integration/bigip_iapp_service.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_iapp_service
+    - bigip_iapp_service

--- a/test/integration/bigip_iapp_template.yaml
+++ b/test/integration/bigip_iapp_template.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_iapp_template
+    - bigip_iapp_template

--- a/test/integration/bigip_iapplx_package.yaml
+++ b/test/integration/bigip_iapplx_package.yaml
@@ -42,11 +42,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_iapplx_package
+    - bigip_iapplx_package

--- a/test/integration/targets/bigip_iapp_service/tasks/issue-00089.yaml
+++ b/test/integration/targets/bigip_iapp_service/tasks/issue-00089.yaml
@@ -2,64 +2,64 @@
 
 - name: Create HTTP iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', item) }}"
-  with_items:
-      - web_frontends.iapp
+    content: "{{ lookup('file', item) }}"
+  loop:
+    - web_frontends.iapp
   register: result
 
 - name: Create a service based on an existing iApp
   bigip_iapp_service:
-      name: "tests"
-      template: "web_frontends"
-      state: "present"
-      parameters:
-          variables:
-              - name: "var__vs_address"
-                value: "1.1.1.1"
-              - name: "pm__apache_servers_for_http"
-                value: "2.2.2.1:80"
-              - name: "pm__apache_servers_for_https"
-                value: "2.2.2.2:80"
+    name: "tests"
+    template: "web_frontends"
+    state: "present"
+    parameters:
+      variables:
+        - name: "var__vs_address"
+          value: "1.1.1.1"
+        - name: "pm__apache_servers_for_http"
+          value: "2.2.2.1:80"
+        - name: "pm__apache_servers_for_https"
+          value: "2.2.2.2:80"
   delegate_to: localhost
 
 - name: Create a service based on an existing iApp - Idempotent check
   bigip_iapp_service:
-      name: "tests"
-      template: "web_frontends"
-      state: "present"
-      parameters:
-          variables:
-              - name: "var__vs_address"
-                value: "1.1.1.1"
-              - name: "pm__apache_servers_for_http"
-                value: "2.2.2.1:80"
-              - name: "pm__apache_servers_for_https"
-                value: "2.2.2.2:80"
+    name: "tests"
+    template: "web_frontends"
+    state: "present"
+    parameters:
+      variables:
+        - name: "var__vs_address"
+          value: "1.1.1.1"
+        - name: "pm__apache_servers_for_http"
+          value: "2.2.2.1:80"
+        - name: "pm__apache_servers_for_https"
+          value: "2.2.2.2:80"
   delegate_to: localhost
 
 - name: Update a service based on an existing iApp
   bigip_iapp_service:
-      name: "tests"
-      template: "web_frontends"
-      state: "present"
-      parameters:
-          variables:
-              - name: "var__vs_address"
-                value: "1.1.1.100"
-              - name: "pm__apache_servers_for_http"
-                value: "20.20.20.1:80"
-              - name: "pm__apache_servers_for_https"
-                value: "3.3.3.3:80"
+    name: "tests"
+    template: "web_frontends"
+    state: "present"
+    parameters:
+      variables:
+        - name: "var__vs_address"
+          value: "1.1.1.100"
+        - name: "pm__apache_servers_for_http"
+          value: "20.20.20.1:80"
+        - name: "pm__apache_servers_for_https"
+          value: "3.3.3.3:80"
   delegate_to: localhost
 
 - name: Remove web_frontends service
   bigip_iapp_service:
-      name: "tests"
-      state: "absent"
+    name: "tests"
+    state: "absent"
   delegate_to: localhost
 
 - name: Remove HTTP iApp template
   bigip_iapp_template:
-      name: "tests"
-      state: "absent"
+    name: "tests"
+    state: "absent"
   register: result

--- a/test/integration/targets/bigip_iapp_service/tasks/issue-00138.yaml
+++ b/test/integration/targets/bigip_iapp_service/tasks/issue-00138.yaml
@@ -2,37 +2,37 @@
 
 - name: Add the iApp contained in template indicated in the content field
   bigip_iapp_template:
-      content: "{{ lookup('template', 'issue-00138/original.iapp') }}"
-      force: "yes"
-      state: "present"
+    content: "{{ lookup('template', 'issue-00138/original.iapp') }}"
+    force: "yes"
+    state: "present"
   delegate_to: localhost
 
 - name: Configure a service based on an existing iApp
   bigip_iapp_service:
-      name: "demo.repro"
-      template: "demo.repro"
-      state: "present"
-      parameters:
-          variables:
-              - name: "var__forwarding_vlans"
-                value: "net2"
+    name: "demo.repro"
+    template: "demo.repro"
+    state: "present"
+    parameters:
+      variables:
+        - name: "var__forwarding_vlans"
+          value: "net2"
   delegate_to: localhost
 
 - name: Update iApp
   bigip_iapp_template:
-      content: "{{ lookup('template', 'issue-00138/updated.iapp') }}"
-      force: "yes"
-      state: "present"
+    content: "{{ lookup('template', 'issue-00138/updated.iapp') }}"
+    force: "yes"
+    state: "present"
   delegate_to: localhost
 
 - name: Re-configure a service based on an existing iApp
   bigip_iapp_service:
-      name: "demo.repro"
-      force: "yes"
-      template: "demo.repro"
-      state: "present"
-      parameters:
-          variables:
-              - name: "var__forwarding_vlans"
-                value: "net2"
+    name: "demo.repro"
+    force: "yes"
+    template: "demo.repro"
+    state: "present"
+    parameters:
+      variables:
+        - name: "var__forwarding_vlans"
+          value: "net2"
   delegate_to: localhost

--- a/test/integration/targets/bigip_iapp_service/tasks/issue-00254.yaml
+++ b/test/integration/targets/bigip_iapp_service/tasks/issue-00254.yaml
@@ -2,55 +2,55 @@
 
 - name: Create a new partition - Issue 254
   bigip_partition:
-      name: "issue-254"
-      state: "present"
+    name: "issue-254"
+    state: "present"
 
 - name: Create HTTP iApp template - Issue 254
   bigip_iapp_template:
-      content: "{{ lookup('file', item) }}"
-  with_items:
-      - f5.http.v1.2.0rc4.tmpl
+    content: "{{ lookup('file', item) }}"
+  loop:
+    - f5.http.v1.2.0rc4.tmpl
   register: result
 
 - name: Create HTTP iApp service from iApp template - Issue 254
   bigip_iapp_service:
-      name: "issue-254-service"
-      template: "/Common/f5.http.v1.2.0rc4"
-      parameters: "{{ lookup('file', 'f5.http.v1.2.0rc4.parameters.json') }}"
-      partition: "issue-254"
+    name: "issue-254-service"
+    template: "/Common/f5.http.v1.2.0rc4"
+    parameters: "{{ lookup('file', 'f5.http.v1.2.0rc4.parameters.json') }}"
+    partition: "issue-254"
   register: result
 
 - name: Assert Create HTTP iApp service from iApp template - Issue 254
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create HTTP iApp service from iApp template - Idempotent check - Issue 254
   bigip_iapp_service:
-      name: "issue-254-service"
-      template: "/Common/f5.http.v1.2.0rc4"
-      parameters: "{{ lookup('file', 'f5.http.v1.2.0rc4.parameters.json') }}"
-      partition: "issue-254"
+    name: "issue-254-service"
+    template: "/Common/f5.http.v1.2.0rc4"
+    parameters: "{{ lookup('file', 'f5.http.v1.2.0rc4.parameters.json') }}"
+    partition: "issue-254"
   register: result
 
 - name: Assert Create HTTP iApp service from iApp template - Idempotent check - Issue 254
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete HTTP iApp service - Issue 254
   bigip_iapp_service:
-      name: "issue-254-service"
-      state: "absent"
-      partition: "issue-254"
+    name: "issue-254-service"
+    state: "absent"
+    partition: "issue-254"
   register: result
 
 - name: Assert Delete HTTP iApp service - Issue 254
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove partition - Issue 254
   bigip_partition:
-      name: "issue-254"
-      state: "absent"
+    name: "issue-254"
+    state: "absent"

--- a/test/integration/targets/bigip_iapp_service/tasks/issue-00263.yaml
+++ b/test/integration/targets/bigip_iapp_service/tasks/issue-00263.yaml
@@ -2,62 +2,62 @@
 
 - name: Create app service integration iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', item) }}"
-  with_items:
-      - appsvcs_integration_v2.0.004.tmpl
+    content: "{{ lookup('file', item) }}"
+  loop:
+    - appsvcs_integration_v2.0.004.tmpl
   register: result
 
 - name: Assert Create app service integration iApp service from iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create app service integration iApp service from iApp template
   bigip_iapp_service:
-      name: "f5-http-url-routing-lb"
-      template: "appsvcs_integration_v2.0.004"
-      parameters: "{{ lookup('file', item) }}"
-  with_items:
-      - f5-http-url-routing-lb.parameters.json
+    name: "f5-http-url-routing-lb"
+    template: "appsvcs_integration_v2.0.004"
+    parameters: "{{ lookup('file', item) }}"
+  loop:
+    - f5-http-url-routing-lb.parameters.json
   register: result
 
 - name: Assert Create app service integration iApp service from iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create app service integration iApp service from iApp template - Idempotent check
   bigip_iapp_service:
-      name: "f5-http-url-routing-lb"
-      template: "appsvcs_integration_v2.0.004"
-      parameters: "{{ lookup('file', item) }}"
-  with_items:
-      - f5-http-url-routing-lb.parameters.json
+    name: "f5-http-url-routing-lb"
+    template: "appsvcs_integration_v2.0.004"
+    parameters: "{{ lookup('file', item) }}"
+  loop:
+    - f5-http-url-routing-lb.parameters.json
   register: result
 
 - name: Assert Create app service integration iApp service from iApp template - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete app service integration iApp service
   bigip_iapp_service:
-      name: "f5-http-url-routing-lb"
-      state: "absent"
+    name: "f5-http-url-routing-lb"
+    state: "absent"
   register: result
 
 - name: Assert Delete app service integration iApp service
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove app service integration iApp template
   bigip_iapp_template:
-      name: "appsvcs_integration_v2.0.004"
-      state: "absent"
+    name: "appsvcs_integration_v2.0.004"
+    state: "absent"
   register: result
 
 - name: Assert Remove app service integration iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed

--- a/test/integration/targets/bigip_iapp_service/tasks/issue-00354.yaml
+++ b/test/integration/targets/bigip_iapp_service/tasks/issue-00354.yaml
@@ -2,30 +2,30 @@
 
 - name: Create HTTP iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', item) }}"
-  with_items:
-      - web_frontends.iapp
+    content: "{{ lookup('file', item) }}"
+  loop:
+    - web_frontends.iapp
   register: result
 
 - name: Create a service based on an existing iApp
   bigip_iapp_service:
-      name: "tests"
-      template: "web_frontends"
-      state: "present"
-      parameters:
-          variables:
-              - name: "var__vs_address"
-                value: "1.1.1.1"
-              - name: "pm__apache_servers_for_http"
-                value: "2.2.2.1:80"
-              - name: "pm__apache_servers_for_https"
-                value: "2.2.2.2:80"
+    name: "tests"
+    template: "web_frontends"
+    state: "present"
+    parameters:
+      variables:
+        - name: "var__vs_address"
+          value: "1.1.1.1"
+        - name: "pm__apache_servers_for_http"
+          value: "2.2.2.1:80"
+        - name: "pm__apache_servers_for_https"
+          value: "2.2.2.2:80"
   delegate_to: localhost
 
 - name: Try to remove the iApp template before the service
   bigip_iapp_template:
-      name: "web_frontends"
-      state: "absent"
+    name: "web_frontends"
+    state: "absent"
   register: result
   failed_when:
     - not result|success
@@ -33,12 +33,12 @@
 
 - name: Remove web_frontends service
   bigip_iapp_service:
-      name: "tests"
-      state: "absent"
+    name: "tests"
+    state: "absent"
   delegate_to: localhost
 
 - name: Remove the iApp template
   bigip_iapp_template:
-      name: "web_frontends"
-      state: "absent"
+    name: "web_frontends"
+    state: "absent"
   register: result

--- a/test/integration/targets/bigip_iapp_service/tasks/main.yaml
+++ b/test/integration/targets/bigip_iapp_service/tasks/main.yaml
@@ -2,127 +2,127 @@
 
 - name: Ensure ASM is provisioned
   bigip_provision:
-      module: "asm"
-      state: "present"
+    module: "asm"
+    state: "present"
 
 - name: Create HTTP iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', item) }}"
-  with_items:
-      - f5.http.v1.2.0rc4.tmpl
-      - appsvcs_integration_v2.0.002.tmpl
+    content: "{{ lookup('file', item) }}"
+  loop:
+    - f5.http.v1.2.0rc4.tmpl
+    - appsvcs_integration_v2.0.002.tmpl
   register: result
 
 - name: Create HTTP iApp service from iApp template
   bigip_iapp_service:
-      name: "foo-service"
-      template: "f5.http.v1.2.0rc4"
-      parameters: "{{ lookup('file', 'f5.http.v1.2.0rc4.parameters.json') }}"
+    name: "foo-service"
+    template: "f5.http.v1.2.0rc4"
+    parameters: "{{ lookup('file', 'f5.http.v1.2.0rc4.parameters.json') }}"
   register: result
 
 - name: Assert Create HTTP iApp service from iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create HTTP iApp service from iApp template - Idempotent check
   bigip_iapp_service:
-      name: "foo-service"
-      template: "f5.http.v1.2.0rc4"
-      parameters: "{{ lookup('file', 'f5.http.v1.2.0rc4.parameters.json') }}"
+    name: "foo-service"
+    template: "f5.http.v1.2.0rc4"
+    parameters: "{{ lookup('file', 'f5.http.v1.2.0rc4.parameters.json') }}"
   register: result
 
 - name: Assert Create HTTP iApp service from iApp template - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete HTTP iApp service
   bigip_iapp_service:
-      name: "foo-service"
-      state: "absent"
+    name: "foo-service"
+    state: "absent"
   register: result
 
 - name: Assert Delete HTTP iApp service
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete HTTP iApp service - Idempotent check
   bigip_iapp_service:
-      name: "foo-service"
-      state: "absent"
+    name: "foo-service"
+    state: "absent"
   register: result
 
 - name: Assert Delete HTTP iApp service - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Create AppSvcs iApp service from iApp template
   bigip_iapp_service:
-      name: "foo-app-service"
-      template: "appsvcs_integration_v2.0.002"
-      parameters: "{{ lookup('file', 'appsvcs_myhttps_w_asm_from_url_payload.json') }}"
+    name: "foo-app-service"
+    template: "appsvcs_integration_v2.0.002"
+    parameters: "{{ lookup('file', 'appsvcs_myhttps_w_asm_from_url_payload.json') }}"
   register: result
 
 - name: Assert Create AppSvcs iApp service from iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create AppSvcs iApp service from iApp template - Idempotent check
   bigip_iapp_service:
-      name: "foo-app-service"
-      template: "appsvcs_integration_v2.0.002"
-      parameters: "{{ lookup('file', 'appsvcs_myhttps_w_asm_from_url_payload.json') }}"
+    name: "foo-app-service"
+    template: "appsvcs_integration_v2.0.002"
+    parameters: "{{ lookup('file', 'appsvcs_myhttps_w_asm_from_url_payload.json') }}"
   register: result
 
 - name: Assert Create AppSvcs iApp service from iApp template - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete AppSvcs iApp service from iApp template
   bigip_iapp_service:
-      name: "foo-app-service"
-      state: "absent"
+    name: "foo-app-service"
+    state: "absent"
   register: result
 
 - name: Assert Delete AppSvcs iApp service from iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete AppSvcs iApp service from iApp template - Idempotent check
   bigip_iapp_service:
-      name: "foo-app-service"
-      state: "absent"
+    name: "foo-app-service"
+    state: "absent"
   register: result
 
 - name: Assert Delete AppSvcs iApp service from iApp template - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 # Github issues
-- include: issue-00089.yaml
+- import_tasks: issue-00089.yaml
   tags: issue-00089
 
-- include: issue-00138.yaml
+- import_tasks: issue-00138.yaml
   tags: issue-00138
 
-- include: issue-00254.yaml
+- import_tasks: issue-00254.yaml
   tags: issue-00254
 
-- include: issue-00263.yaml
+- import_tasks: issue-00263.yaml
   tags: issue-00263
 
-- include: issue-00307.yaml
+- import_tasks: issue-00307.yaml
   tags: issue-00307
 
-- include: issue-00354.yaml
+- import_tasks: issue-00354.yaml
   tags: issue-00354
 
-- include: issue-00359.yaml
+- import_tasks: issue-00359.yaml
   tags: issue-00359

--- a/test/integration/targets/bigip_iapp_template/defaults/main.yaml
+++ b/test/integration/targets/bigip_iapp_template/defaults/main.yaml
@@ -4,18 +4,18 @@ template_name: "good_templ"
 template_file: "basic-iapp.tmpl"
 
 template_list:
-    - appsvcs_integration_v2.0_001.tmpl
-    - f5.accel_disable_by_cookie.v1.0.0.tmpl
-    - f5.citrix_vdi.v2.4.0.tmpl
-    - f5.http.v1.2.0rc4.tmpl
-    - f5.microsoft_adfs.v1.0.0.tmpl
-    - f5.microsoft_dynamics_crm_2011_2013.v1.0.0.tmpl
-    - f5.microsoft_exchange_2010_2013_cas.v1.6.0.tmpl
-    - f5.microsoft_exchange_2016.v1.0.0.tmpl
-    - f5.microsoft_lync_server_2010_2013.v1.3.0.tmpl
-    - f5.microsoft_office_365_idp.v1.1.0.tmpl
-    - f5.microsoft_rds_remote_access.v1.0.2.tmpl
-    - f5.microsoft_rds_session_host.v1.0.3.tmpl
-    - f5.microsoft_sharepoint_2010_2013.v1.2.1.tmpl
-    - f5.ssl_intercept.v1.0.0.tmpl
-    - f5.vmware_view.v1.5.1.tmpl
+  - appsvcs_integration_v2.0_001.tmpl
+  - f5.accel_disable_by_cookie.v1.0.0.tmpl
+  - f5.citrix_vdi.v2.4.0.tmpl
+  - f5.http.v1.2.0rc4.tmpl
+  - f5.microsoft_adfs.v1.0.0.tmpl
+  - f5.microsoft_dynamics_crm_2011_2013.v1.0.0.tmpl
+  - f5.microsoft_exchange_2010_2013_cas.v1.6.0.tmpl
+  - f5.microsoft_exchange_2016.v1.0.0.tmpl
+  - f5.microsoft_lync_server_2010_2013.v1.3.0.tmpl
+  - f5.microsoft_office_365_idp.v1.1.0.tmpl
+  - f5.microsoft_rds_remote_access.v1.0.2.tmpl
+  - f5.microsoft_rds_session_host.v1.0.3.tmpl
+  - f5.microsoft_sharepoint_2010_2013.v1.2.1.tmpl
+  - f5.ssl_intercept.v1.0.0.tmpl
+  - f5.vmware_view.v1.5.1.tmpl

--- a/test/integration/targets/bigip_iapp_template/tasks/issue-00126.yaml
+++ b/test/integration/targets/bigip_iapp_template/tasks/issue-00126.yaml
@@ -2,12 +2,12 @@
 
 - name: Issue 00126 - Create iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', 'web_frontends.tmpl') }}"
-      state: "present"
+    content: "{{ lookup('file', 'web_frontends.tmpl') }}"
+    state: "present"
   register: result
 
 - name: Issue 00126 - Remove iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', 'web_frontends.tmpl') }}"
-      state: "absent"
+    content: "{{ lookup('file', 'web_frontends.tmpl') }}"
+    state: "absent"
   register: result

--- a/test/integration/targets/bigip_iapp_template/tasks/issue-00136.yaml
+++ b/test/integration/targets/bigip_iapp_template/tasks/issue-00136.yaml
@@ -2,25 +2,25 @@
 
 - name: Issue 00136 - Add the iApp contained in template indicated in the content field
   bigip_iapp_template:
-      content: "{{ lookup('template', 'issue-00136/original.iapp') }}"
-      force: "yes"
-      state: "present"
+    content: "{{ lookup('template', 'issue-00136/original.iapp') }}"
+    force: "yes"
+    state: "present"
   delegate_to: localhost
 
 - name: Issue 00136 - Configure a service based on an existing iApp
   bigip_iapp_service:
-      name: "demo.repro"
-      template: "demo.repro"
-      state: "present"
-      parameters:
-          variables:
-              - name: "var__forwarding_vlans"
-                value: "net2"
+    name: "demo.repro"
+    template: "demo.repro"
+    state: "present"
+    parameters:
+      variables:
+        - name: "var__forwarding_vlans"
+          value: "net2"
   delegate_to: localhost
 
 - name: Issue 00136 - Update iApp
   bigip_iapp_template:
-      content: "{{ lookup('template', 'issue-00136/updated.iapp') }}"
-      force: "yes"
-      state: "present"
+    content: "{{ lookup('template', 'issue-00136/updated.iapp') }}"
+    force: "yes"
+    state: "present"
   delegate_to: localhost

--- a/test/integration/targets/bigip_iapp_template/tasks/main.yaml
+++ b/test/integration/targets/bigip_iapp_template/tasks/main.yaml
@@ -2,58 +2,58 @@
 
 - name: Create iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
+    content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
   register: result
 
 - name: Assert Create iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create iApp template - Idempotent check
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
+    content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
   register: result
 
 - name: Assert Create iApp template - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete iApp template
   bigip_iapp_template:
-      name: "{{ template_name }}"
-      state: "absent"
+    name: "{{ template_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Delete iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete iApp template - Idempotent check
   bigip_iapp_template:
-      name: "{{ template_name }}"
-      state: "absent"
+    name: "{{ template_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Delete iApp template - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Create list of iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', item) }}"
+    content: "{{ lookup('file', item) }}"
   register: result
-  with_items: "{{ template_list }}"
+  loop: "{{ template_list }}"
 
 - name: Delete list of iApp template
   bigip_iapp_template:
-      name: "{{ item|basename|splitext|first }}"
-      state: "absent"
+    name: "{{ item|basename|splitext|first }}"
+    state: "absent"
   register: result
-  with_items: "{{ template_list }}"
+  loop: "{{ template_list }}"
 
 - import_tasks: test-force.yaml
   tags: test-force

--- a/test/integration/targets/bigip_iapp_template/tasks/test-force-with-service.yaml
+++ b/test/integration/targets/bigip_iapp_template/tasks/test-force-with-service.yaml
@@ -2,45 +2,45 @@
 
 - name: Create iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
+    content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
   register: result
 
 - name: Create service from iApp template
   bigip_iapp_service:
-      name: "foo-service"
-      template: "good_templ"
+    name: "foo-service"
+    template: "good_templ"
   register: result
 
 - name: Update iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
-      force: yes
+    content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
+    force: yes
   register: result
 
 - name: Assert Update iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Update iApp template - Idempotent check
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
-      force: yes
+    content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
+    force: yes
   register: result
 
 - name: Assert Update iApp template - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove service
   bigip_iapp_service:
-      name: "foo-service"
-      state: "absent"
+    name: "foo-service"
+    state: "absent"
   register: result
 
 - name: Remove iApp template
   bigip_iapp_template:
-      name: "good_templ"
-      state: "absent"
+    name: "good_templ"
+    state: "absent"
   register: result

--- a/test/integration/targets/bigip_iapp_template/tasks/test-force-without-service.yaml
+++ b/test/integration/targets/bigip_iapp_template/tasks/test-force-without-service.yaml
@@ -1,32 +1,32 @@
 - name: Create iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
+    content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
   register: result
 
 - name: Update iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
-      force: yes
+    content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
+    force: yes
   register: result
 
 - name: Assert Update iApp template
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Update iApp template - Idempotent check
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
-      force: yes
+    content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
+    force: yes
   register: result
 
 - name: Assert Update iApp template - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove iApp template
   bigip_iapp_template:
-      name: "good_templ"
-      state: "absent"
+    name: "good_templ"
+    state: "absent"
   register: result

--- a/test/integration/targets/bigip_iapp_template/tasks/test-force.yaml
+++ b/test/integration/targets/bigip_iapp_template/tasks/test-force.yaml
@@ -1,11 +1,11 @@
 ---
 
-- include: test-force-with-service.yaml
+- import_tasks: test-force-with-service.yaml
   tags:
-      - test-force
-- include: test-force-without-service.yaml
+    - test-force
+- import_tasks: test-force-without-service.yaml
   tags:
-      - test-force
-- include: test-no-force-with-service.yaml
+    - test-force
+- import_tasks: test-no-force-with-service.yaml
   tags:
-      - test-force
+    - test-force

--- a/test/integration/targets/bigip_iapp_template/tasks/test-no-force-with-service.yaml
+++ b/test/integration/targets/bigip_iapp_template/tasks/test-no-force-with-service.yaml
@@ -2,43 +2,43 @@
 
 - name: Create iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
+    content: "{{ lookup('file', 'basic-iapp.tmpl') }}"
   register: result
 
 - name: Create service from iApp template
   bigip_iapp_service:
-      name: "foo-service"
-      template: "good_templ"
+    name: "foo-service"
+    template: "good_templ"
   register: result
 
 - name: Update iApp template
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
+    content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
   register: result
 
 - name: Assert Update iApp template
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Update iApp template - Idempotent check
   bigip_iapp_template:
-      content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
+    content: "{{ lookup('file', 'basic-iapp-changed.tmpl') }}"
   register: result
 
 - name: Assert Update iApp template - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove service
   bigip_iapp_service:
-      name: "foo-service"
-      state: "absent"
+    name: "foo-service"
+    state: "absent"
   register: result
 
 - name: Remove iApp template
   bigip_iapp_template:
-      name: "good_templ"
-      state: "absent"
+    name: "good_templ"
+    state: "absent"
   register: result

--- a/test/integration/targets/bigip_iapplx_package/tasks/main.yaml
+++ b/test/integration/targets/bigip_iapplx_package/tasks/main.yaml
@@ -2,77 +2,77 @@
 
 - name: Create iAppLX package
   bigip_iapplx_package:
-      package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
-      state: "present"
+    package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
+    state: "present"
   register: result
 
 - name: Assert Create iAppLX package
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create iAppLX package - Idempotent check
   bigip_iapplx_package:
-      package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
-      state: "present"
+    package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
+    state: "present"
   register: result
 
 - name: Assert Create iAppLX package - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete iAppLX package
   bigip_iapplx_package:
-      package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
-      state: "absent"
+    package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
+    state: "absent"
   register: result
 
 - name: Assert Delete iAppLX package
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete iAppLX package - Idempotent check
   bigip_iapplx_package:
-      package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
-      state: "absent"
+    package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
+    state: "absent"
   register: result
 
 - name: Assert Create iAppLX package - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Create iAppLX package
   bigip_iapplx_package:
-      package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
-      state: "present"
+    package: "{{ role_path }}/files/MyApp-0.1.0-0001.noarch.rpm"
+    state: "present"
   register: result
 
 - name: Assert Create iAppLX package
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete iAppLX package, file does not exist
   bigip_iapplx_package:
-      package: "MyApp-0.1.0-0001.noarch.rpm"
-      state: "absent"
+    package: "MyApp-0.1.0-0001.noarch.rpm"
+    state: "absent"
   register: result
 
 - name: Assert Delete iAppLX package, file does not exist
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete iAppLX package, file does not exist - Idempotent check
   bigip_iapplx_package:
-      package: "MyApp-0.1.0-0001.noarch.rpm"
-      state: "absent"
+    package: "MyApp-0.1.0-0001.noarch.rpm"
+    state: "absent"
   register: result
 
 - name: Assert Delete iAppLX package, file does not exist - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed


### PR DESCRIPTION
…_template, and iapplx_package.

1. Standardize on 2-spaces indents.
2. Replace 'include: *.yaml' with 'import_tasks: *.yaml'.
3. Replace 'with_items:' with 'loop:'