### PR TITLE
Standards in hostname, irule, and license modules.

### DIFF
--- a/test/integration/bigip_hostname.yaml
+++ b/test/integration/bigip_hostname.yaml
@@ -42,11 +42,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_hostname
+    - bigip_hostname

--- a/test/integration/bigip_irule.yaml
+++ b/test/integration/bigip_irule.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_irule
+    - bigip_irule

--- a/test/integration/bigip_license.yaml
+++ b/test/integration/bigip_license.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_license
+    - bigip_license

--- a/test/integration/targets/bigip_hostname/tasks/main.yaml
+++ b/test/integration/targets/bigip_hostname/tasks/main.yaml
@@ -2,43 +2,43 @@
 
 - name: Change the hostname
   bigip_hostname:
-      hostname: "{{ valid_hostname }}"
+    hostname: "{{ valid_hostname }}"
   register: result
 
 - name: Assert Change the hostname
   assert:
-      that:
-          - result|changed
-          - result['hostname'] == valid_hostname
+    that:
+      - result|changed
+      - result['hostname'] == valid_hostname
 
 - name: Change the hostname - Idempotent check
   bigip_hostname:
-      hostname: "{{ valid_hostname }}"
+    hostname: "{{ valid_hostname }}"
   register: result
 
 - name: Assert Change the hostname - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change the hostname, invalid name
   bigip_hostname:
-      hostname: "{{ invalid_hostname }}"
+    hostname: "{{ invalid_hostname }}"
   register: result
   ignore_errors: true
 
 - name: Assert Change the hostname, invalid name
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change the hostname, invalid name - Idempotent check
   bigip_hostname:
-      hostname: "{{ invalid_hostname }}"
+    hostname: "{{ invalid_hostname }}"
   register: result
   ignore_errors: true
 
 - name: Assert Change the hostname, invalid name - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_irule/tasks/issue-00042.yaml
+++ b/test/integration/targets/bigip_irule/tasks/issue-00042.yaml
@@ -2,43 +2,43 @@
 
 - name: Delete iRule with space at the end - Setup - Issue 42
   bigip_irule:
-      module: "ltm"
-      name: "issue-42"
-      state: "absent"
+    module: "ltm"
+    name: "issue-42"
+    state: "absent"
   register: result
 
 - name: Create iRule with space at the end - Issue 42
   bigip_irule:
-      content: "when HTTP_REQUEST {HTTP::respond 200 content 'Good Request'}\n"
-      module: "ltm"
-      name: "issue-42"
+    content: "when HTTP_REQUEST {HTTP::respond 200 content 'Good Request'}\n"
+    module: "ltm"
+    name: "issue-42"
   register: result
 
 - name: Assert Create iRule with space at the end - Issue 42
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create iRule with space at the end - Issue 42 - Idempotent check
   bigip_irule:
-      content: "when HTTP_REQUEST {HTTP::respond 200 content 'Good Request'}\n"
-      module: "ltm"
-      name: "issue-42"
+    content: "when HTTP_REQUEST {HTTP::respond 200 content 'Good Request'}\n"
+    module: "ltm"
+    name: "issue-42"
   register: result
 
 - name: Assert Create iRule with space at the end - Issue 42 - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete iRule with space at the end - Teardown - Issue 42
   bigip_irule:
-      module: "ltm"
-      name: "issue-42"
-      state: "absent"
+    module: "ltm"
+    name: "issue-42"
+    state: "absent"
   register: result
 
 - name: Assert Delete iRule with space at the end - Teardown - Issue 42
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed

--- a/test/integration/targets/bigip_irule/tasks/issue-00316.yaml
+++ b/test/integration/targets/bigip_irule/tasks/issue-00316.yaml
@@ -2,39 +2,39 @@
 
 - name: Add the iRule - Issue 316
   bigip_irule:
-      name: "issue-316"
-      src: "{{ role_path }}/files/irule-01.tcl"
-      module: "ltm"
-      state: "present"
+    name: "issue-316"
+    src: "{{ role_path }}/files/irule-01.tcl"
+    module: "ltm"
+    state: "present"
   register: result
 
 - name: Assert Add the iRule - Issue 316
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Add the iRule - Issue 316 - Idempotent check
   bigip_irule:
-      name: "issue-316"
-      src: "{{ role_path }}/files/irule-01.tcl"
-      module: "ltm"
-      state: "present"
+    name: "issue-316"
+    src: "{{ role_path }}/files/irule-01.tcl"
+    module: "ltm"
+    state: "present"
   register: result
 
 - name: Assert Add the iRule - Issue 316 - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove the iRule - Issue 316
   bigip_irule:
-      name: "issue-316"
-      src: "{{ role_path }}/files/irule-01.tcl"
-      module: "ltm"
-      state: "absent"
+    name: "issue-316"
+    src: "{{ role_path }}/files/irule-01.tcl"
+    module: "ltm"
+    state: "absent"
   register: result
 
 - name: Assert Remove the iRule - Issue 316
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed

--- a/test/integration/targets/bigip_irule/tasks/main.yaml
+++ b/test/integration/targets/bigip_irule/tasks/main.yaml
@@ -1,159 +1,159 @@
 ---
 
-- include: setup.yaml
+- import_tasks: setup.yaml
 
 - name: Create iRule in LTM
   bigip_irule:
-      content: "{{ lookup('template', 'irule-01.tcl') }}"
-      module: "ltm"
-      name: "{{ irule_name_ltm }}"
+    content: "{{ lookup('template', 'irule-01.tcl') }}"
+    module: "ltm"
+    name: "{{ irule_name_ltm }}"
   register: result
 
 - name: Assert Create iRule in LTM
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create iRule in LTM - Idempotent check
   bigip_irule:
-      content: "{{ lookup('template', 'irule-01.tcl') }}"
-      module: "ltm"
-      name: "{{ irule_name_ltm }}"
+    content: "{{ lookup('template', 'irule-01.tcl') }}"
+    module: "ltm"
+    name: "{{ irule_name_ltm }}"
   register: result
 
 - name: Assert Create iRule in LTM - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Modify iRule in LTM
   bigip_irule:
-      content: "{{ lookup('file', 'irule-01.tcl') }}"
-      module: "ltm"
-      name: "{{ irule_name_ltm }}"
+    content: "{{ lookup('file', 'irule-01.tcl') }}"
+    module: "ltm"
+    name: "{{ irule_name_ltm }}"
   register: result
 
 - name: Assert Modify iRule in LTM
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Modify iRule in LTM - Idempotent check
   bigip_irule:
-      content: "{{ lookup('file', 'irule-01.tcl') }}"
-      module: "ltm"
-      name: "{{ irule_name_ltm }}"
+    content: "{{ lookup('file', 'irule-01.tcl') }}"
+    module: "ltm"
+    name: "{{ irule_name_ltm }}"
   register: result
 
 - name: Assert Modify iRule in LTM - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete iRule in LTM
   bigip_irule:
-      module: "ltm"
-      name: "{{ irule_name_ltm }}"
-      state: "absent"
+    module: "ltm"
+    name: "{{ irule_name_ltm }}"
+    state: "absent"
   register: result
 
 - name: Assert Delete iRule in LTM
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete iRule in LTM - Idempotent check
   bigip_irule:
-      module: "ltm"
-      name: "{{ irule_name_ltm }}"
-      state: "absent"
+    module: "ltm"
+    name: "{{ irule_name_ltm }}"
+    state: "absent"
   register: result
 
 - name: Assert Delete iRule in LTM - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Create iRule in GTM
   bigip_irule:
-      content: "{{ lookup('template', 'irule-02.tcl') }}"
-      module: "gtm"
-      name: "{{ irule_name_gtm }}"
+    content: "{{ lookup('template', 'irule-02.tcl') }}"
+    module: "gtm"
+    name: "{{ irule_name_gtm }}"
   register: result
 
 - name: Assert Create iRule in GTM
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create iRule in GTM - Idempotent check
   bigip_irule:
-      content: "{{ lookup('template', 'irule-02.tcl') }}"
-      module: "gtm"
-      name: "{{ irule_name_gtm }}"
+    content: "{{ lookup('template', 'irule-02.tcl') }}"
+    module: "gtm"
+    name: "{{ irule_name_gtm }}"
   register: result
 
 - name: Assert Create iRule in GTM - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Modify iRule in GTM
   bigip_irule:
-      content: "{{ lookup('file', 'irule-02.tcl') }}"
-      module: "gtm"
-      name: "{{ irule_name_gtm }}"
+    content: "{{ lookup('file', 'irule-02.tcl') }}"
+    module: "gtm"
+    name: "{{ irule_name_gtm }}"
   register: result
 
 - name: Assert Modify iRule in GTM
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Modify iRule in GTM - Idempotent check
   bigip_irule:
-      content: "{{ lookup('file', 'irule-02.tcl') }}"
-      module: "gtm"
-      name: "{{ irule_name_gtm }}"
+    content: "{{ lookup('file', 'irule-02.tcl') }}"
+    module: "gtm"
+    name: "{{ irule_name_gtm }}"
   register: result
 
 - name: Assert Modify iRule in GTM - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete iRule in GTM
   bigip_irule:
-      module: "gtm"
-      name: "{{ irule_name_gtm }}"
-      state: "absent"
+    module: "gtm"
+    name: "{{ irule_name_gtm }}"
+    state: "absent"
   register: result
 
 - name: Assert Delete iRule in GTM
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete iRule in GTM - Idempotent check
   bigip_irule:
-      module: "gtm"
-      name: "{{ irule_name_gtm }}"
-      state: "absent"
+    module: "gtm"
+    name: "{{ irule_name_gtm }}"
+    state: "absent"
   register: result
 
 - name: Assert Delete iRule in GTM - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 # Tests for different issues filed on Github
-- include: issue-00042.yaml
+- import_tasks: issue-00042.yaml
   tags: issue-00042
 
-- include: issue-00316.yaml
+- import_tasks: issue-00316.yaml
   tags: issue-00316
 
-- include: issue-00416.yaml
+- import_tasks: issue-00416.yaml
   tags: issue-00416
 
-- include: teardown.yaml
+- import_tasks: teardown.yaml

--- a/test/integration/targets/bigip_irule/tasks/setup.yaml
+++ b/test/integration/targets/bigip_irule/tasks/setup.yaml
@@ -2,5 +2,5 @@
 
 - name: Provision GTM on the device
   bigip_provision:
-      module: "gtm"
+    module: "gtm"
   register: result

--- a/test/integration/targets/bigip_irule/tasks/teardown.yaml
+++ b/test/integration/targets/bigip_irule/tasks/teardown.yaml
@@ -2,6 +2,6 @@
 
 - name: De-provision GTM on the device
   bigip_provision:
-      module: "gtm"
-      state: "absent"
+    module: "gtm"
+    state: "absent"
   register: result

--- a/test/integration/targets/bigip_license/tasks/main.yaml
+++ b/test/integration/targets/bigip_license/tasks/main.yaml
@@ -2,10 +2,10 @@
 
 - name: License BIG-IP
   bigip_license:
-      key: "{{ bigip_license }}"
+    key: "{{ bigip_license }}"
   register: result
 
 - name: Assert License BIG-IP
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed


### PR DESCRIPTION
2-space indents.
Replace "include: *.yaml" with "import_tasks: *.yaml"