### PR TITLE
Formatting and standards updates to all monitor modules.

### DIFF
--- a/test/integration/bigip_monitor_http.yaml
+++ b/test/integration/bigip_monitor_http.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_monitor_http
+    - bigip_monitor_http

--- a/test/integration/bigip_monitor_https.yaml
+++ b/test/integration/bigip_monitor_https.yaml
@@ -39,11 +39,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_monitor_https
+    - bigip_monitor_https

--- a/test/integration/bigip_monitor_snmp_dca.yaml
+++ b/test/integration/bigip_monitor_snmp_dca.yaml
@@ -39,11 +39,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_monitor_snmp_dca
+    - bigip_monitor_snmp_dca

--- a/test/integration/bigip_monitor_tcp.yaml
+++ b/test/integration/bigip_monitor_tcp.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_monitor_tcp
+    - bigip_monitor_tcp

--- a/test/integration/bigip_monitor_tcp_echo.yaml
+++ b/test/integration/bigip_monitor_tcp_echo.yaml
@@ -50,11 +50,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_monitor_tcp_echo
+    - bigip_monitor_tcp_echo

--- a/test/integration/bigip_monitor_tcp_half_open.yaml
+++ b/test/integration/bigip_monitor_tcp_half_open.yaml
@@ -50,11 +50,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_monitor_tcp_half_open
+    - bigip_monitor_tcp_half_open

--- a/test/integration/targets/bigip_monitor_http/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_http/tasks/main.yaml
@@ -2,226 +2,226 @@
 
 - name: Create HTTP Monitor
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string1 }}"
-      send: "{{ send_string1 }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string1 }}"
+    send: "{{ send_string1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create HTTP Monitor
   assert:
-      that:
-          - result|changed
-          - result.send == send_string1
-          - result.receive == receive_string1
+    that:
+      - result|changed
+      - result.send == send_string1
+      - result.receive == receive_string1
 
 - name: Create HTTP Monitor - Idempotent check
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string1 }}"
-      send: "{{ send_string1 }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string1 }}"
+    send: "{{ send_string1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create HTTP Monitor - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change send string
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      send: "{{ send_string2 }}"
+    name: "{{ monitor_name }}"
+    send: "{{ send_string2 }}"
   register: result
 
 - name: Assert Change send string
   assert:
-      that:
-          - result|changed
-          - result.send == send_string2
+    that:
+      - result|changed
+      - result.send == send_string2
 
 - name: Change send string - Idempotent check
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      send: "{{ send_string2 }}"
+    name: "{{ monitor_name }}"
+    send: "{{ send_string2 }}"
   register: result
 
 - name: Assert Change send string - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change receive string
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string2 }}"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string2 }}"
   register: result
 
 - name: Assert Change receive string
   assert:
-      that:
-          - result|changed
-          - result.receive == receive_string2
+    that:
+      - result|changed
+      - result.receive == receive_string2
 
 - name: Change receive string - Idempotent check
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string2 }}"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string2 }}"
   register: result
 
 - name: Assert Change receive string - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change IP
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
   register: result
 
 - name: Assert Change IP
   assert:
-      that:
-          - result|changed
-          - result.ip == '10.10.10.10'
-          - result.port == 80
+    that:
+      - result|changed
+      - result.ip == '10.10.10.10'
+      - result.port == 80
 
 - name: Change IP - Idempotent check
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
   register: result
 
 - name: Assert Change IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change port
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      port: 8000
+    name: "{{ monitor_name }}"
+    port: 8000
   register: result
 
 - name: Assert Change port
   assert:
-      that:
-          - result|changed
-          - result.port == 8000
+    that:
+      - result|changed
+      - result.port == 8000
 
 - name: Change port - Idempotent check
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      port: 8000
+    name: "{{ monitor_name }}"
+    port: 8000
   register: result
 
 - name: Assert Change port - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, less than timeout
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout
   assert:
-      that:
-          - result|changed
-          - result.interval == 2
+    that:
+      - result|changed
+      - result.interval == 2
 
 - name: Change interval, less than timeout - Idempotent check
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, greater than timeout, expect failure
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      interval: 200
+    name: "{{ monitor_name }}"
+    interval: 200
   register: result
   ignore_errors: true
 
 - name: Assert Change interval, greater than timeout, expect failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change timeout
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout
   assert:
-      that:
-          - result|changed
-          - result.timeout == 80
+    that:
+      - result|changed
+      - result.timeout == 80
 
 - name: Change timeout - Idempotent check
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change time until up
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up
   assert:
-      that:
-          - result|changed
-          - result.time_until_up == 80
+    that:
+      - result|changed
+      - result.time_until_up == 80
 
 - name: Change time until up - Idempotent check
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove HTTP Monitor
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove HTTP Monitor
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove HTTP Monitor - Idempotent check
   bigip_monitor_http:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove HTTP Monitor - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_monitor_https/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_https/tasks/main.yaml
@@ -4,228 +4,228 @@
 
 - name: Create HTTPS Monitor
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string1 }}"
-      send: "{{ send_string1 }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string1 }}"
+    send: "{{ send_string1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create HTTPS Monitor
   assert:
-      that:
-          - result|changed
-          - result.send == send_string1
-          - result.receive == receive_string1
+    that:
+      - result|changed
+      - result.send == send_string1
+      - result.receive == receive_string1
 
 - name: Create HTTPS Monitor - Idempotent check
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string1 }}"
-      send: "{{ send_string1 }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string1 }}"
+    send: "{{ send_string1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create HTTPS Monitor - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change send string
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      send: "{{ send_string2 }}"
+    name: "{{ monitor_name }}"
+    send: "{{ send_string2 }}"
   register: result
 
 - name: Assert Change send string
   assert:
-      that:
-          - result|changed
-          - result.send == send_string2
+    that:
+      - result|changed
+      - result.send == send_string2
 
 - name: Change send string - Idempotent check
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      send: "{{ send_string2 }}"
+    name: "{{ monitor_name }}"
+    send: "{{ send_string2 }}"
   register: result
 
 - name: Assert Change send string - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change receive string
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string2 }}"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string2 }}"
   register: result
 
 - name: Assert Change receive string
   assert:
-      that:
-          - result|changed
-          - result.receive == receive_string2
+    that:
+      - result|changed
+      - result.receive == receive_string2
 
 - name: Change receive string - Idempotent check
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string2 }}"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string2 }}"
   register: result
 
 - name: Assert Change receive string - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change IP
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
   register: result
 
 - name: Assert Change IP
   assert:
-      that:
-          - result|changed
-          - result.ip == '10.10.10.10'
-          - result.port == 80
+    that:
+      - result|changed
+      - result.ip == '10.10.10.10'
+      - result.port == 80
 
 - name: Change IP - Idempotent check
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
   register: result
 
 - name: Assert Change IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change port
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      port: 8000
+    name: "{{ monitor_name }}"
+    port: 8000
   register: result
 
 - name: Assert Change port
   assert:
-      that:
-          - result|changed
-          - result.port == 8000
+    that:
+      - result|changed
+      - result.port == 8000
 
 - name: Change port - Idempotent check
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      port: 8000
+    name: "{{ monitor_name }}"
+    port: 8000
   register: result
 
 - name: Assert Change port - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, less than timeout
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout
   assert:
-      that:
-          - result|changed
-          - result.interval == 2
+    that:
+      - result|changed
+      - result.interval == 2
 
 - name: Change interval, less than timeout - Idempotent check
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, greater than timeout, expect failure
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      interval: 200
+    name: "{{ monitor_name }}"
+    interval: 200
   register: result
   ignore_errors: true
 
 - name: Assert Change interval, greater than timeout, expect failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change timeout
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout
   assert:
       that:
-          - result|changed
-          - result.timeout == 80
+        - result|changed
+        - result.timeout == 80
 
 - name: Change timeout - Idempotent check
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change time until up
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up
   assert:
-      that:
-          - result|changed
-          - result.time_until_up == 80
+    that:
+      - result|changed
+      - result.time_until_up == 80
 
 - name: Change time until up - Idempotent check
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove HTTPS Monitor
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove HTTPS Monitor
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove HTTPS Monitor - Idempotent check
   bigip_monitor_https:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove HTTPS Monitor - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - import_tasks: teardown.yaml

--- a/test/integration/targets/bigip_monitor_snmp_dca/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_snmp_dca/tasks/main.yaml
@@ -2,392 +2,392 @@
 
 - name: Create SNMP DCA Monitor
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create SNMP DCA Monitor
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create SNMP DCA Monitor - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create SNMP DCA Monitor - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, less than timeout
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change interval, less than timeout - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, greater than timeout, expect failure
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      interval: 200
+    name: "{{ monitor_name }}"
+    interval: 200
   register: result
   ignore_errors: true
 
 - name: Assert Change interval, greater than timeout, expect failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change timeout
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change timeout - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change time until up
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change time until up - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change community
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      community: "foobar"
+    name: "{{ monitor_name }}"
+    community: "foobar"
   register: result
 
 - name: Assert Change community
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change community - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      community: "foobar"
+    name: "{{ monitor_name }}"
+    community: "foobar"
   register: result
 
 - name: Assert Change community - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change version
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      version: "v2c"
+    name: "{{ monitor_name }}"
+    version: "v2c"
   register: result
 
 - name: Assert Change version
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change version - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      version: "v2c"
+    name: "{{ monitor_name }}"
+    version: "v2c"
   register: result
 
 - name: Assert Change version - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change agent type
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      agent_type: "WIN2000"
+    name: "{{ monitor_name }}"
+    agent_type: "WIN2000"
   register: result
 
 - name: Assert Change agent type
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change agent type - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      agent_type: "WIN2000"
+    name: "{{ monitor_name }}"
+    agent_type: "WIN2000"
   register: result
 
 - name: Assert Change agent type - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change CPU coefficient
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      cpu_coefficient: "30"
+    name: "{{ monitor_name }}"
+    cpu_coefficient: "30"
   register: result
 
 - name: Assert Change CPU coefficient
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change CPU coefficient - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      cpu_coefficient: "30"
+    name: "{{ monitor_name }}"
+    cpu_coefficient: "30"
   register: result
 
 - name: Assert Change CPU coefficient - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change CPU coefficient - expected failure
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      cpu_coefficient: "abc123"
+    name: "{{ monitor_name }}"
+    cpu_coefficient: "abc123"
   register: result
   ignore_errors: true
 
 - name: Assert Change CPU coefficient - expected failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change CPU threshold
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      cpu_threshold: "30"
+    name: "{{ monitor_name }}"
+    cpu_threshold: "30"
   register: result
 
 - name: Assert Change CPU threshold
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change CPU threshold - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      cpu_threshold: "30"
+    name: "{{ monitor_name }}"
+    cpu_threshold: "30"
   register: result
 
 - name: Assert Change CPU threshold - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change CPU threshold - expected failure
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      cpu_threshold: "abc123"
+    name: "{{ monitor_name }}"
+    cpu_threshold: "abc123"
   register: result
   ignore_errors: true
 
 - name: Assert Change CPU threshold - expected failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change memory coefficient
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      memory_coefficient: "30"
+    name: "{{ monitor_name }}"
+    memory_coefficient: "30"
   register: result
 
 - name: Assert Change memory coefficient
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change memory coefficient - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      memory_coefficient: "30"
+    name: "{{ monitor_name }}"
+    memory_coefficient: "30"
   register: result
 
 - name: Assert Change memory coefficient - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change memory coefficient - expected failure
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      memory_coefficient: "abc123"
+    name: "{{ monitor_name }}"
+    memory_coefficient: "abc123"
   register: result
   ignore_errors: true
 
 - name: Assert Change memory coefficient - expected failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change memory threshold
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      memory_threshold: "30"
+    name: "{{ monitor_name }}"
+    memory_threshold: "30"
   register: result
 
 - name: Assert Change memory threshold
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change memory threshold - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      memory_threshold: "30"
+    name: "{{ monitor_name }}"
+    memory_threshold: "30"
   register: result
 
 - name: Assert Change memory threshold - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change memory threshold - expected failure
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      memory_threshold: "abc123"
+    name: "{{ monitor_name }}"
+    memory_threshold: "abc123"
   register: result
   ignore_errors: true
 
 - name: Assert Change memory threshold - expected failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change disk coefficient
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      disk_coefficient: "30"
+    name: "{{ monitor_name }}"
+    disk_coefficient: "30"
   register: result
 
 - name: Assert Change disk coefficient
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change disk coefficient - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      disk_coefficient: "30"
+    name: "{{ monitor_name }}"
+    disk_coefficient: "30"
   register: result
 
 - name: Assert Change disk coefficient - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change disk coefficient - expected failure
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      disk_coefficient: "abc123"
+    name: "{{ monitor_name }}"
+    disk_coefficient: "abc123"
   register: result
   ignore_errors: true
 
 - name: Assert Change disk coefficient - expected failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change disk threshold
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      disk_threshold: "30"
+    name: "{{ monitor_name }}"
+    disk_threshold: "30"
   register: result
 
 - name: Assert Change disk threshold
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change disk threshold - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      disk_threshold: "30"
+    name: "{{ monitor_name }}"
+    disk_threshold: "30"
   register: result
 
 - name: Assert Change disk threshold - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change disk threshold - expected failure
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      disk_threshold: "abc123"
+    name: "{{ monitor_name }}"
+    disk_threshold: "abc123"
   register: result
   ignore_errors: true
 
 - name: Assert Change disk threshold - expected failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove Monitor
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove Monitor
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove Monitor - Idempotent check
   bigip_monitor_snmp_dca:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove Monitor - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_monitor_tcp/tasks/legacy_tcp_echo.yaml
+++ b/test/integration/targets/bigip_monitor_tcp/tasks/legacy_tcp_echo.yaml
@@ -2,159 +2,159 @@
 
 - name: Create TCP Monitor - Echo
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "present"
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    state: "present"
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Create TCP Monitor - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create TCP Monitor - Echo - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "present"
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    state: "present"
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Create TCP Monitor - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change IP - Echo
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Change IP - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change IP - Echo - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Change IP - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, less than timeout - Echo
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      interval: 2
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    interval: 2
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Change interval, less than timeout - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change interval, less than timeout - Echo - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      interval: 2
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    interval: 2
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Change interval, less than timeout - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, greater than timeout, expect failure - Echo
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      interval: 200
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    interval: 200
+    type: "TTYPE_TCP_ECHO"
   register: result
   ignore_errors: true
 
 - name: Assert Change interval, greater than timeout, expect failure - Echo
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change timeout - Echo
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      timeout: 80
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    timeout: 80
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Change timeout - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change timeout - Echo - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      timeout: 80
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    timeout: 80
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Change timeout - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change time until up - Echo
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    time_until_up: 80
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Change time until up - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change time until up - Echo - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    time_until_up: 80
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Change time until up - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove TCP Monitor - Echo
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "absent"
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    state: "absent"
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Remove TCP Monitor - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove TCP Monitor - Echo - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "absent"
-      type: "TTYPE_TCP_ECHO"
+    name: "{{ monitor_name }}"
+    state: "absent"
+    type: "TTYPE_TCP_ECHO"
   register: result
 
 - name: Assert Remove TCP Monitor - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_monitor_tcp/tasks/legacy_tcp_half_open.yaml
+++ b/test/integration/targets/bigip_monitor_tcp/tasks/legacy_tcp_half_open.yaml
@@ -2,183 +2,183 @@
 
 - name: Create TCP Monitor - Half Open
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "present"
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    state: "present"
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Create TCP Monitor - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create TCP Monitor - Half Open - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "present"
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    state: "present"
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Create TCP Monitor - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change IP - Half Open
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change IP - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change IP - Half Open - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change IP - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change port - Half Open
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      port: 8000
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    port: 8000
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change port - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change port - Half Open - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      port: 8000
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    port: 8000
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change port - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, less than timeout - Half Open
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      interval: 2
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    interval: 2
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change interval, less than timeout - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change interval, less than timeout - Half Open - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      interval: 2
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    interval: 2
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change interval, less than timeout - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, greater than timeout, expect failure - Half Open
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      interval: 200
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    interval: 200
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
   ignore_errors: true
 
 - name: Assert Change interval, greater than timeout, expect failure - Half Open
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change timeout - Half Open
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      timeout: 80
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    timeout: 80
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change timeout - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change timeout - Half Open - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      timeout: 80
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    timeout: 80
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change timeout - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change time until up - Half Open
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    time_until_up: 80
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change time until up - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change time until up - Half Open - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    time_until_up: 80
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Change time until up - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove TCP Monitor - Half Open
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "absent"
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    state: "absent"
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Remove TCP Monitor - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove TCP Monitor - Half Open - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "absent"
-      type: "TTYPE_TCP_HALF_OPEN"
+    name: "{{ monitor_name }}"
+    state: "absent"
+    type: "TTYPE_TCP_HALF_OPEN"
   register: result
 
 - name: Assert Remove TCP Monitor - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_monitor_tcp/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_tcp/tasks/main.yaml
@@ -2,230 +2,230 @@
 
 - name: Create TCP Monitor
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string1 }}"
-      send: "{{ send_string1 }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string1 }}"
+    send: "{{ send_string1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create TCP Monitor
   assert:
-      that:
-          - result|changed
-          - result.send == send_string1
-          - result.receive == receive_string1
+    that:
+      - result|changed
+      - result.send == send_string1
+      - result.receive == receive_string1
 
 - name: Create TCP Monitor - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string1 }}"
-      send: "{{ send_string1 }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string1 }}"
+    send: "{{ send_string1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create TCP Monitor - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change send string
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      send: "{{ send_string2 }}"
+    name: "{{ monitor_name }}"
+    send: "{{ send_string2 }}"
   register: result
 
 - name: Assert Change send string
   assert:
-      that:
-          - result|changed
-          - result.send == send_string2
+    that:
+      - result|changed
+      - result.send == send_string2
 
 - name: Change send string - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      send: "{{ send_string2 }}"
+    name: "{{ monitor_name }}"
+    send: "{{ send_string2 }}"
   register: result
 
 - name: Assert Change send string - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change receive string
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string2 }}"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string2 }}"
   register: result
 
 - name: Assert Change receive string
   assert:
-      that:
-          - result|changed
-          - result.receive == receive_string2
+    that:
+      - result|changed
+      - result.receive == receive_string2
 
 - name: Change receive string - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      receive: "{{ receive_string2 }}"
+    name: "{{ monitor_name }}"
+    receive: "{{ receive_string2 }}"
   register: result
 
 - name: Assert Change receive string - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change IP
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
   register: result
 
 - name: Assert Change IP
   assert:
-      that:
-          - result|changed
-          - result.ip == '10.10.10.10'
-          - result.port == 80
+    that:
+      - result|changed
+      - result.ip == '10.10.10.10'
+      - result.port == 80
 
 - name: Change IP - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
   register: result
 
 - name: Assert Change IP - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change port
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      port: 8000
+    name: "{{ monitor_name }}"
+    port: 8000
   register: result
 
 - name: Assert Change port
   assert:
-      that:
-          - result|changed
-          - result.port == 8000
+    that:
+      - result|changed
+      - result.port == 8000
 
 - name: Change port - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      port: 8000
+    name: "{{ monitor_name }}"
+    port: 8000
   register: result
 
 - name: Assert Change port - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, less than timeout
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout
   assert:
-      that:
-          - result|changed
-          - result.interval == 2
+    that:
+      - result|changed
+      - result.interval == 2
 
 - name: Change interval, less than timeout - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, greater than timeout, expect failure
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      interval: 200
+    name: "{{ monitor_name }}"
+    interval: 200
   register: result
   ignore_errors: true
 
 - name: Assert Change interval, greater than timeout, expect failure
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change timeout
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout
   assert:
-      that:
-          - result|changed
-          - result.timeout == 80
+    that:
+      - result|changed
+      - result.timeout == 80
 
 - name: Change timeout - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change time until up
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up
   assert:
-      that:
-          - result|changed
-          - result.time_until_up == 80
+    that:
+      - result|changed
+      - result.time_until_up == 80
 
 - name: Change time until up - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove TCP Monitor
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove TCP Monitor
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove TCP Monitor - Idempotent check
   bigip_monitor_tcp:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove TCP Monitor - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 # TODO: These tests should be in their own modules. Move in 2.5
-- include: legacy_tcp_echo.yaml
-- include: legacy_tcp_half_open.yaml
+- import_tasks: legacy_tcp_echo.yaml
+- import_tasks: legacy_tcp_half_open.yaml

--- a/test/integration/targets/bigip_monitor_tcp_echo/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_tcp_echo/tasks/main.yaml
@@ -2,144 +2,144 @@
 
 - name: Create TCP Monitor - Echo
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create TCP Monitor - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create TCP Monitor - Echo - Idempotent check
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create TCP Monitor - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change IP - Echo
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
   register: result
 
 - name: Assert Change IP - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change IP - Echo - Idempotent check
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
   register: result
 
 - name: Assert Change IP - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, less than timeout - Echo
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change interval, less than timeout - Echo - Idempotent check
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, greater than timeout, expect failure - Echo
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      interval: 200
+    name: "{{ monitor_name }}"
+    interval: 200
   register: result
   ignore_errors: true
 
 - name: Assert Change interval, greater than timeout, expect failure - Echo
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change timeout - Echo
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change timeout - Echo - Idempotent check
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change time until up - Echo
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change time until up - Echo - Idempotent check
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove TCP Monitor - Echo
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove TCP Monitor - Echo
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove TCP Monitor - Echo - Idempotent check
   bigip_monitor_tcp_echo:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove TCP Monitor - Echo - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_monitor_tcp_half_open/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_tcp_half_open/tasks/main.yaml
@@ -2,168 +2,168 @@
 
 - name: Create TCP Monitor - Half Open
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create TCP Monitor - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create TCP Monitor - Half Open - Idempotent check
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      state: "present"
+    name: "{{ monitor_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create TCP Monitor - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change IP - Half Open
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
   register: result
 
 - name: Assert Change IP - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change IP - Half Open - Idempotent check
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      ip: "10.10.10.10"
-      port: 80
+    name: "{{ monitor_name }}"
+    ip: "10.10.10.10"
+    port: 80
   register: result
 
 - name: Assert Change IP - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change port - Half Open
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      port: 8000
+    name: "{{ monitor_name }}"
+    port: 8000
   register: result
 
 - name: Assert Change port - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change port - Half Open - Idempotent check
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      port: 8000
+    name: "{{ monitor_name }}"
+    port: 8000
   register: result
 
 - name: Assert Change port - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, less than timeout - Half Open
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change interval, less than timeout - Half Open - Idempotent check
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      interval: 2
+    name: "{{ monitor_name }}"
+    interval: 2
   register: result
 
 - name: Assert Change interval, less than timeout - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change interval, greater than timeout, expect failure - Half Open
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      interval: 200
+    name: "{{ monitor_name }}"
+    interval: 200
   register: result
   ignore_errors: true
 
 - name: Assert Change interval, greater than timeout, expect failure - Half Open
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change timeout - Half Open
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change timeout - Half Open - Idempotent check
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      timeout: 80
+    name: "{{ monitor_name }}"
+    timeout: 80
   register: result
 
 - name: Assert Change timeout - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change time until up - Half Open
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change time until up - Half Open - Idempotent check
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      time_until_up: 80
+    name: "{{ monitor_name }}"
+    time_until_up: 80
   register: result
 
 - name: Assert Change time until up - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove TCP Monitor - Half Open
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove TCP Monitor - Half Open
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove TCP Monitor - Half Open - Idempotent check
   bigip_monitor_tcp_half_open:
-      name: "{{ monitor_name }}"
-      state: "absent"
+    name: "{{ monitor_name }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove TCP Monitor - Half Open - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed


### PR DESCRIPTION
Standardize on 2-space indents.
Replace "include: *.yaml" with "import_tasks: *.yaml"