### PR TITLE
Applying standards to node, partition, policy, and policy_rule modules.

### DIFF
--- a/test/integration/bigip_node.yaml
+++ b/test/integration/bigip_node.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_node
+    - bigip_node

--- a/test/integration/bigip_partition.yaml
+++ b/test/integration/bigip_partition.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_partition
+    - bigip_partition

--- a/test/integration/bigip_policy.yaml
+++ b/test/integration/bigip_policy.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_policy
+    - bigip_policy

--- a/test/integration/bigip_policy_rule.yaml
+++ b/test/integration/bigip_policy_rule.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_policy_rule
+    - bigip_policy_rule

--- a/test/integration/targets/bigip_node/defaults/main.yaml
+++ b/test/integration/targets/bigip_node/defaults/main.yaml
@@ -7,11 +7,11 @@ node_name: "foo.example"
 node_description: "foo node"
 availability_requirement: "at_least"
 node_monitors:
-    - "icmp"
-    - "gateway_icmp"
+  - "icmp"
+  - "gateway_icmp"
 node_monitors_changed:
-    - "icmp"
-    - "gateway_icmp"
-    - "http"
+  - "icmp"
+  - "gateway_icmp"
+  - "http"
 node_quorum: 1
 monitor_type: "and_list"

--- a/test/integration/targets/bigip_node/tasks/node-by-address-ipv4.yaml
+++ b/test/integration/targets/bigip_node/tasks/node-by-address-ipv4.yaml
@@ -2,46 +2,46 @@
 
 - name: Create node
   bigip_node:
-      host: "{{ node_host_ipv4 }}"
-      name: "{{ node_name }}"
-      state: "present"
+    host: "{{ node_host_ipv4 }}"
+    name: "{{ node_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create node
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create node - Idempotent check
   bigip_node:
-      host: "{{ node_host_ipv4 }}"
-      name: "{{ node_name }}"
-      state: "present"
+    host: "{{ node_host_ipv4 }}"
+    name: "{{ node_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create node - Idempotent check
   assert:
-      that:
-        - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete node
   bigip_node:
-      name: "{{ node_name }}"
-      state: "absent"
+    name: "{{ node_name }}"
+    state: "absent"
   register: result
 
 - name: Assert delete node
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete node - Idempotent check
   bigip_node:
-      name: "{{ node_name }}"
-      state: "absent"
+    name: "{{ node_name }}"
+    state: "absent"
   register: result
 
 - name: Assert delete node - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_node/tasks/node-by-address-ipv6.yaml
+++ b/test/integration/targets/bigip_node/tasks/node-by-address-ipv6.yaml
@@ -2,46 +2,46 @@
 
 - name: Create node
   bigip_node:
-      host: "{{ node_host_ipv6 }}"
-      name: "{{ node_name }}"
-      state: "present"
+    host: "{{ node_host_ipv6 }}"
+    name: "{{ node_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create node
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create node - Idempotent check
   bigip_node:
-      host: "{{ node_host_ipv6 }}"
-      name: "{{ node_name }}"
-      state: "present"
+    host: "{{ node_host_ipv6 }}"
+    name: "{{ node_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create node - Idempotent check
   assert:
-      that:
-        - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete node
   bigip_node:
-      name: "{{ node_name }}"
-      state: "absent"
+    name: "{{ node_name }}"
+    state: "absent"
   register: result
 
 - name: Assert delete node
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete node - Idempotent check
   bigip_node:
-      name: "{{ node_name }}"
-      state: "absent"
+    name: "{{ node_name }}"
+    state: "absent"
   register: result
 
 - name: Assert delete node - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_node/tasks/node-by-fqdn.yaml
+++ b/test/integration/targets/bigip_node/tasks/node-by-fqdn.yaml
@@ -2,81 +2,81 @@
 
 - name: Create node
   bigip_node:
-      fqdn: "{{ node_host_fqdn }}"
-      name: "{{ node_name }}"
-      state: "present"
+    fqdn: "{{ node_host_fqdn }}"
+    name: "{{ node_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create node
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create node - Idempotent check
   bigip_node:
-      fqdn: "{{ node_host_fqdn }}"
-      name: "{{ node_name }}"
-      state: "present"
+    fqdn: "{{ node_host_fqdn }}"
+    name: "{{ node_name }}"
+    state: "present"
   register: result
 
 - name: Assert Create node - Idempotent check
   assert:
-      that:
-        - not result|changed
+    that:
+      - not result|changed
 
 - name: Change node description
   bigip_node:
-      description: "new {{ node_description }}"
-      name: "{{ node_name }}"
+    description: "new {{ node_description }}"
+    name: "{{ node_name }}"
   register: result
 
 - name: Assert change node description
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change node description - Idempotent check
   bigip_node:
-      description: "new {{ node_description }}"
-      name: "{{ node_name }}"
+    description: "new {{ node_description }}"
+    name: "{{ node_name }}"
   register: result
 
 - name: Assert change node description - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete node
   bigip_node:
-      name: "{{ node_name }}"
-      state: "absent"
+    name: "{{ node_name }}"
+    state: "absent"
   register: result
 
 - name: Assert delete node
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete node - Idempotent check
   bigip_node:
-      name: "{{ node_name }}"
-      state: "absent"
+    name: "{{ node_name }}"
+    state: "absent"
   register: result
 
 - name: Assert delete node - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Create node without FQDN or Address
   bigip_node:
-      name: "{{ node_name }}"
-      state: "present"
+    name: "{{ node_name }}"
+    state: "present"
   register: result
   ignore_errors: true
 
 - name: Assert Create node without FQDN or Address
   assert:
-      that:
-          - not result|changed
-          - "'At least one of \\'address\\' or \\'fqdn\\'' in result.msg"
+    that:
+      - not result|changed
+      - "'At least one of \\'address\\' or \\'fqdn\\'' in result.msg"

--- a/test/integration/targets/bigip_node/tasks/node-monitors.yaml
+++ b/test/integration/targets/bigip_node/tasks/node-monitors.yaml
@@ -2,94 +2,94 @@
 
 - name: Include variables
   include_vars:
-      file: node-monitors.yaml
+    file: node-monitors.yaml
 
 - name: Create node with multiple monitors
   bigip_node:
-      state: "present"
-      name: "{{ node1['name'] }}"
-      fqdn: "{{ node1['fqdn'] }}"
-      monitors: "{{ node1['monitors'] }}"
-      monitor_type: "{{ node1['monitor_type'] }}"
+    state: "present"
+    name: "{{ node1['name'] }}"
+    fqdn: "{{ node1['fqdn'] }}"
+    monitors: "{{ node1['monitors'] }}"
+    monitor_type: "{{ node1['monitor_type'] }}"
   register: result
 
 - name: Assert Create node with multiple monitors
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create node with multiple monitors - Idempotent check
   bigip_node:
-      state: "present"
-      name: "{{ node1['name'] }}"
-      fqdn: "{{ node1['fqdn'] }}"
-      monitors: "{{ node1['monitors'] }}"
-      monitor_type: "{{ node1['monitor_type'] }}"
+    state: "present"
+    name: "{{ node1['name'] }}"
+    fqdn: "{{ node1['fqdn'] }}"
+    monitors: "{{ node1['monitors'] }}"
+    monitor_type: "{{ node1['monitor_type'] }}"
   register: result
 
 - name: Assert Create node with multiple monitors - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change node to single monitor - Expected error due to multiple existing monitors
   bigip_node:
-      state: "present"
-      name: "{{ node1['name'] }}"
-      monitor_type: "{{ node2['monitor_type'] }}"
+    state: "present"
+    name: "{{ node1['name'] }}"
+    monitor_type: "{{ node2['monitor_type'] }}"
   register: result
   ignore_errors: true
 
 - name: Assert Change node to single monitor - Expected error due to multiple existing monitors
   assert:
-      that:
-          - not result|changed
-          - "'A single monitor must be specified' in result.msg"
+    that:
+      - not result|changed
+      - "'A single monitor must be specified' in result.msg"
 
 - name: Change node to single monitor
   bigip_node:
-      state: "present"
-      name: "{{ node1['name'] }}"
-      monitors: "{{ node2['monitors'] }}"
-      monitor_type: "{{ node2['monitor_type'] }}"
+    state: "present"
+    name: "{{ node1['name'] }}"
+    monitors: "{{ node2['monitors'] }}"
+    monitor_type: "{{ node2['monitor_type'] }}"
   register: result
 
 - name: Assert Change node to single monitor
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change node to single monitor - Idempotent check
   bigip_node:
-      state: "present"
-      name: "{{ node1['name'] }}"
-      monitors: "{{ node2['monitors'] }}"
-      monitor_type: "{{ node2['monitor_type'] }}"
+    state: "present"
+    name: "{{ node1['name'] }}"
+    monitors: "{{ node2['monitors'] }}"
+    monitor_type: "{{ node2['monitor_type'] }}"
   register: result
 
 - name: Assert Change node to single monitor - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete node
   bigip_node:
-      name: "{{ node1['name'] }}"
-      state: "absent"
+    name: "{{ node1['name'] }}"
+    state: "absent"
   register: result
 
 - name: Assert delete node
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete node - Idempotent check
   bigip_node:
-      name: "{{ node1['name'] }}"
-      state: "absent"
+    name: "{{ node1['name'] }}"
+    state: "absent"
   register: result
 
 - name: Assert delete node - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_node/tasks/status-disabled.yaml
+++ b/test/integration/targets/bigip_node/tasks/status-disabled.yaml
@@ -4,161 +4,161 @@
 
 - name: Reset node to disabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "disabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "disabled"
   register: result
 
 - name: Change node to enabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "enabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "enabled"
   register: result
 
 - name: Assert Change node to enabled
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to disabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "disabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "disabled"
   register: result
 
 - name: Change node to offline
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "offline"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "offline"
   register: result
 
 - name: Assert Change node to offline
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to disabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "disabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "disabled"
   register: result
 
 - name: Change node to present
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "present"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "present"
   register: result
 
 - name: Assert Change node to present
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Create disabled node - address
   bigip_node:
-      address: "8.8.8.8"
-      name: "google-public-dns-a.google.com"
-      state: "disabled"
+    address: "8.8.8.8"
+    name: "google-public-dns-a.google.com"
+    state: "disabled"
   register: result
 
 - name: Change node to enabled
   bigip_node:
-      name: "google-public-dns-a.google.com"
-      state: "enabled"
+    name: "google-public-dns-a.google.com"
+    state: "enabled"
   register: result
 
 - name: Assert Change node to enabled
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to disabled
   bigip_node:
-      name: "google-public-dns-a.google.com"
-      state: "disabled"
+    name: "google-public-dns-a.google.com"
+    state: "disabled"
   register: result
 
 - name: Change node to offline
   bigip_node:
-      name: "google-public-dns-a.google.com"
-      state: "offline"
+    name: "google-public-dns-a.google.com"
+    state: "offline"
   register: result
 
 - name: Assert Change node to offline
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to disabled
   bigip_node:
-      name: "google-public-dns-a.google.com"
-      state: "disabled"
+    name: "google-public-dns-a.google.com"
+    state: "disabled"
   register: result
 
 - name: Change node to present
   bigip_node:
-      name: "google-public-dns-a.google.com"
-      state: "present"
+    name: "google-public-dns-a.google.com"
+    state: "present"
   register: result
 
 - name: Assert Change node to present
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Create disabled node - IPv6 address
   bigip_node:
-      address: "2600:1409:a:186::255e"
-      name: "mit-v6"
-      state: "disabled"
+    address: "2600:1409:a:186::255e"
+    name: "mit-v6"
+    state: "disabled"
   register: result
 
 - name: Change node to enabled
   bigip_node:
-      name: "mit-v6"
-      state: "enabled"
+    name: "mit-v6"
+    state: "enabled"
   register: result
 
 - name: Assert Change node to enabled
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to disabled
   bigip_node:
-      name: "mit-v6"
-      state: "disabled"
+    name: "mit-v6"
+    state: "disabled"
   register: result
 
 - name: Change node to offline
   bigip_node:
-      name: "mit-v6"
-      state: "offline"
+    name: "mit-v6"
+    state: "offline"
   register: result
 
 - name: Assert Change node to offline
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to disabled
   bigip_node:
-      name: "mit-v6"
-      state: "disabled"
+    name: "mit-v6"
+    state: "disabled"
   register: result
 
 - name: Change node to present
   bigip_node:
-      name: "mit-v6"
-      state: "present"
+    name: "mit-v6"
+    state: "present"
   register: result
 
 - name: Assert Change node to present
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed

--- a/test/integration/targets/bigip_node/tasks/status-enabled.yaml
+++ b/test/integration/targets/bigip_node/tasks/status-enabled.yaml
@@ -4,57 +4,57 @@
 
 - name: Reset node to enabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "enabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "enabled"
   register: result
 
 - name: Change node to disabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "disabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "disabled"
   register: result
 
 - name: Assert Change node to disabled
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to disabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "enabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "enabled"
   register: result
 
 - name: Change node to offline
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "offline"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "offline"
   register: result
 
 - name: Assert Change node to offline
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to enabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "enabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "enabled"
   register: result
 
 - name: Change node to present
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "present"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "present"
   register: result
 
 - name: Assert Change node to present
   assert:
-      that:
-        - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_node/tasks/status-offline.yaml
+++ b/test/integration/targets/bigip_node/tasks/status-offline.yaml
@@ -4,57 +4,57 @@
 
 - name: Reset node to offline
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "offline"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "offline"
   register: result
 
 - name: Change node to enabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "enabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "enabled"
   register: result
 
 - name: Assert Change node to enabled
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to offline
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "offline"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "offline"
   register: result
 
 - name: Change node to disabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "disabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "disabled"
   register: result
 
 - name: Assert Change node to disabled
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node to offline
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "offline"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "offline"
   register: result
 
 - name: Change node to present
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "present"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "present"
   register: result
 
 - name: Assert Change node to present
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed

--- a/test/integration/targets/bigip_node/tasks/status-present.yaml
+++ b/test/integration/targets/bigip_node/tasks/status-present.yaml
@@ -4,58 +4,58 @@
 
 - name: Reset node to present
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "present"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "present"
   register: result
 
 - name: Change node to enabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "enabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "enabled"
   register: result
 
 # The two are equivalent. This should register no change
 - name: Assert Change node to enabled
   assert:
-      that:
-        - not result|changed
+    that:
+      - not result|changed
 
 - name: Reset node to present
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "present"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "present"
   register: result
 
 - name: Change node to disabled
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "disabled"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "disabled"
   register: result
 
 - name: Assert Change node to disabled
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Reset node present
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "present"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "present"
   register: result
 
 - name: Change node to offline
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "offline"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "offline"
   register: result
 
 - name: Assert Change node to offline
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed

--- a/test/integration/targets/bigip_node/tasks/statuses.yaml
+++ b/test/integration/targets/bigip_node/tasks/statuses.yaml
@@ -13,99 +13,99 @@
 
 - name: Create present node
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "present"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "present"
   register: result
 
 - name: Assert Create present node
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Create present node - Idempotent check
   bigip_node:
-      fqdn: "microsoft.com"
-      name: "microsoft.com"
-      state: "present"
+    fqdn: "microsoft.com"
+    name: "microsoft.com"
+    state: "present"
   register: result
 
 - name: Assert Create present node - Idempotent check
   assert:
-      that:
-        - not result|changed
+    that:
+      - not result|changed
 
 - name: Create enabled node
   bigip_node:
-      fqdn: "google.com"
-      name: "google.com"
-      state: "enabled"
+    fqdn: "google.com"
+    name: "google.com"
+    state: "enabled"
   register: result
 
 - name: Assert Create enabled node
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Create enabled node - Idempotent check
   bigip_node:
-      fqdn: "google.com"
-      name: "google.com"
-      state: "enabled"
+    fqdn: "google.com"
+    name: "google.com"
+    state: "enabled"
   register: result
 
 - name: Assert Create enabled node - Idempotent check
   assert:
-      that:
-        - not result|changed
+    that:
+      - not result|changed
 
 - name: Create disabled node
   bigip_node:
-      fqdn: "mit.edu"
-      name: "mit.edu"
-      state: "disabled"
+    fqdn: "mit.edu"
+    name: "mit.edu"
+    state: "disabled"
   register: result
 
 - name: Assert Create disabled node
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Create disabled node - Idempotent check
   bigip_node:
-      fqdn: "mit.edu"
-      name: "mit.edu"
-      state: "disabled"
+    fqdn: "mit.edu"
+    name: "mit.edu"
+    state: "disabled"
   register: result
 
 - name: Assert Create disabled node - Idempotent check
   assert:
-      that:
-        - not result|changed
+    that:
+      - not result|changed
 
 - name: Create offline node
   bigip_node:
-      fqdn: "apple.com"
-      name: "apple.com"
-      state: "offline"
+    fqdn: "apple.com"
+    name: "apple.com"
+    state: "offline"
   register: result
 
 - name: Assert Create offline node
   assert:
-      that:
-        - result|changed
+    that:
+      - result|changed
 
 - name: Create offline node - Idempotent check
   bigip_node:
-      fqdn: "apple.com"
-      name: "apple.com"
-      state: "offline"
+    fqdn: "apple.com"
+    name: "apple.com"
+    state: "offline"
   register: result
 
 - name: Assert Create offline node - Idempotent check
   assert:
-      that:
-        - not result|changed
+    that:
+      - not result|changed
 
 - import_tasks: status-disabled.yaml
 - import_tasks: status-enabled.yaml
@@ -114,12 +114,12 @@
 
 - name: Remove nodes
   bigip_node:
-      name: "{{ item }}"
-      state: "absent"
-  with_items:
-      - "google.com"
-      - "mit.edu"
-      - "apple.com"
-      - "microsoft.com"
-      - "google-public-dns-a.google.com"
-      - "mit-v6"
+    name: "{{ item }}"
+    state: "absent"
+  loop:
+    - "google.com"
+    - "mit.edu"
+    - "apple.com"
+    - "microsoft.com"
+    - "google-public-dns-a.google.com"
+    - "mit-v6"

--- a/test/integration/targets/bigip_node/vars/node-monitors.yaml
+++ b/test/integration/targets/bigip_node/vars/node-monitors.yaml
@@ -1,15 +1,15 @@
 ---
 
 node1:
-    state: present
-    fqdn: "foo.monitor.com"
-    name: test_node
-    monitors:
-        - icmp
-        - tcp_echo
-    monitor_type: and_list
+  state: present
+  fqdn: "foo.monitor.com"
+  name: test_node
+  monitors:
+    - icmp
+    - tcp_echo
+  monitor_type: and_list
 
 node2:
-    state: present
-    monitors: icmp
-    monitor_type: single
+  state: present
+  monitors: icmp
+  monitor_type: single

--- a/test/integration/targets/bigip_partition/tasks/main.yaml
+++ b/test/integration/targets/bigip_partition/tasks/main.yaml
@@ -1,82 +1,82 @@
 ---
 
-- include: setup.yaml
+- import_tasks: setup.yaml
 
 - name: Create partition
   bigip_partition:
-      name: "{{ partition }}"
-      route_domain: "{{ route_domain1 }}"
+    name: "{{ partition }}"
+    route_domain: "{{ route_domain1 }}"
   register: result
 
 - name: Assert Create partition
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create partition - Idempotent check
   bigip_partition:
-      name: "{{ partition }}"
-      route_domain: "{{ route_domain1 }}"
+    name: "{{ partition }}"
+    route_domain: "{{ route_domain1 }}"
   register: result
 
 - name: Assert Create partition - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Change partition description
   bigip_partition:
-      description: "{{ description }}"
-      name: "{{ partition }}"
+    description: "{{ description }}"
+    name: "{{ partition }}"
   register: result
 
 - name: Assert Change partition description
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Change partition description - Idempotent check
   bigip_partition:
-      description: "{{ description }}"
-      name: "{{ partition }}"
+    description: "{{ description }}"
+    name: "{{ partition }}"
   register: result
 
 - name: Assert Change partition description - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Reset route domain
   bigip_partition:
-      name: "{{ partition }}"
-      route_domain: "{{ route_domain_default }}"
+    name: "{{ partition }}"
+    route_domain: "{{ route_domain_default }}"
   register: result
 
 - name: Assert Reset route domain
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete partition
   bigip_partition:
-      name: "{{ partition }}"
-      state: "absent"
+    name: "{{ partition }}"
+    state: "absent"
   register: result
 
 - name: Assert Delete partition
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete partition - Idempotent check
   bigip_partition:
-      name: "{{ partition }}"
-      state: "absent"
+    name: "{{ partition }}"
+    state: "absent"
   register: result
 
 - name: Assert Delete partition - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
-- include: teardown.yaml
+- import_tasks: teardown.yaml

--- a/test/integration/targets/bigip_partition/tasks/setup.yaml
+++ b/test/integration/targets/bigip_partition/tasks/setup.yaml
@@ -2,8 +2,8 @@
 
 - name: Create route domains
   bigip_routedomain:
-      id: "{{ item }}"
-      state: "present"
-  with_items:
-      - 1
-      - 2
+    id: "{{ item }}"
+    state: "present"
+  loop:
+    - 1
+    - 2

--- a/test/integration/targets/bigip_partition/tasks/teardown.yaml
+++ b/test/integration/targets/bigip_partition/tasks/teardown.yaml
@@ -2,8 +2,8 @@
 
 - name: Remove route domains
   bigip_routedomain:
-      id: "{{ item }}"
-      state: "absent"
-  with_items:
-      - 1
-      - 2
+    id: "{{ item }}"
+    state: "absent"
+  loop:
+    - 1
+    - 2

--- a/test/integration/targets/bigip_policy/tasks/main-draft.yaml
+++ b/test/integration/targets/bigip_policy/tasks/main-draft.yaml
@@ -14,7 +14,7 @@
 - name: Assert Create a published policy
   assert:
     that:
-       - result|changed
+      - result|changed
 
 - name: Create a published policy - Idempotent check
   bigip_policy:

--- a/test/integration/targets/bigip_policy_rule/tasks/teardown.yaml
+++ b/test/integration/targets/bigip_policy_rule/tasks/teardown.yaml
@@ -4,7 +4,7 @@
   bigip_policy:
     name: "{{ item }}"
     state: present
-  with_items:
+  loop:
     - "{{ policy_name1 }}"
     - "{{ policy_name2 }}"
 


### PR DESCRIPTION
- Standardize on 2-space indents
- Replace "with_items:" with "loop:"
- Replace "include: *.yaml" with "import_tasks: *.yaml"