### PR TITLE
Formating and standardization for provision, qkview, raw, and remote_…

### DIFF
--- a/test/integration/bigip_provision.yaml
+++ b/test/integration/bigip_provision.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_provision
+    - bigip_provision

--- a/test/integration/bigip_qkview.yaml
+++ b/test/integration/bigip_qkview.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_qkview
+    - bigip_qkview

--- a/test/integration/bigip_raw.yaml
+++ b/test/integration/bigip_raw.yaml
@@ -39,11 +39,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_raw
+    - bigip_raw

--- a/test/integration/bigip_remote_syslog.yaml
+++ b/test/integration/bigip_remote_syslog.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_remote_syslog
+    - bigip_remote_syslog

--- a/test/integration/targets/bigip_pool_member/tasks/main.yaml
+++ b/test/integration/targets/bigip_pool_member/tasks/main.yaml
@@ -175,6 +175,6 @@
     that:
       - result|changed
 
-- include: pr-23128.yaml
+- import_tasks: pr-23128.yaml
   tags:
     - pr-23128

--- a/test/integration/targets/bigip_provision/tasks/main.yaml
+++ b/test/integration/targets/bigip_provision/tasks/main.yaml
@@ -33,84 +33,84 @@
 
 - name: Deprovision GTM on the device - Idempotent check
   bigip_provision:
-      module: "{{ module1 }}"
-      state: "absent"
+    module: "{{ module1 }}"
+    state: "absent"
   register: result
 
 - name: Assert Deprovision GTM on the device - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Provision two modules
   bigip_provision:
-      module: "{{ item }}"
-  with_items:
-      - gtm
-      - asm
+    module: "{{ item }}"
+  loop:
+    - gtm
+    - asm
   register: result
 
 - name: Assert Provision two modules
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Provision two modules - Idempotent check
   bigip_provision:
-      module: "{{ item }}"
-  with_items:
-      - gtm
-      - asm
+    module: "{{ item }}"
+  loop:
+    - gtm
+    - asm
   register: result
 
 - name: Assert Provision two modules
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Deprovision first module
   bigip_provision:
-      module: "gtm"
-      state: "absent"
+    module: "gtm"
+    state: "absent"
   register: result
 
 - name: Assert Deprovision first module
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Deprovision first module - Idempotent check
   bigip_provision:
-      module: "gtm"
-      state: "absent"
+    module: "gtm"
+    state: "absent"
   register: result
 
 - name: Assert Deprovision first module - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Deprovision second module
   bigip_provision:
-      module: "asm"
-      state: "absent"
+    module: "asm"
+    state: "absent"
   register: result
 
 - name: Assert Deprovision second module
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Deprovision second module - Idempotent check
   bigip_provision:
-      module: "gtm"
-      state: "absent"
+    module: "gtm"
+    state: "absent"
   register: result
 
 - name: Assert Deprovision second module - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - import_tasks: issue-00449.yaml
   tags: issue-00449

--- a/test/integration/targets/bigip_qkview/tasks/main.yaml
+++ b/test/integration/targets/bigip_qkview/tasks/main.yaml
@@ -1,49 +1,49 @@
 ---
 
-- include: setup.yaml
+- import_tasks: setup.yaml
 
 - name: Create QKView, save it locally
   bigip_qkview:
-      dest: "{{ qkview_path_local }}"
+    dest: "{{ qkview_path_local }}"
 
 - name: Check for existence
   stat:
-      path: "{{ qkview_path_local }}"
+    path: "{{ qkview_path_local }}"
   register: st
 
 - name: Assert Check for existence
   assert:
-      that:
-          - st.stat.exists|bool
+    that:
+      - st.stat.exists|bool
 
 - name: Remove qkview file
   file:
-      path: "{{ qkview_path_local }}"
-      state: "absent"
+    path: "{{ qkview_path_local }}"
+    state: "absent"
 
 - name: Create QKView with options, save it locally
   bigip_qkview:
-      asm_request_log: yes
-      exclude_core: yes
-      exclude:
-          - audit
-          - secure
-      dest: "{{ qkview_path_local }}"
+    asm_request_log: yes
+    exclude_core: yes
+    exclude:
+      - audit
+      - secure
+    dest: "{{ qkview_path_local }}"
 
 - name: Check for existence
   stat:
-      path: "{{ qkview_path_local }}"
+    path: "{{ qkview_path_local }}"
   register: st
 
 - name: Assert Check for existence
   assert:
-      that:
-          - st.stat.exists|bool
+    that:
+      - st.stat.exists|bool
 
 - name: Remove qkview file
   file:
-      path: "{{ qkview_path_local }}"
-      state: "absent"
+    path: "{{ qkview_path_local }}"
+    state: "absent"
 
 #- name: The whole enchilada
 #  bigip_qkview:

--- a/test/integration/targets/bigip_raw/tasks/main.yaml
+++ b/test/integration/targets/bigip_raw/tasks/main.yaml
@@ -2,62 +2,62 @@
 
 - name: Run single command
   bigip_raw:
-      commands:
-          - "tmsh show sys version"
+    commands:
+      - "tmsh show sys version"
   register: result
 
 - name: Assert Run single command
   assert:
-      that:
-          - result.stdout_lines|length == 1
+    that:
+      - result.stdout_lines|length == 1
 
 - name: Run multiple commands
   bigip_raw:
-      commands:
-          - "tmsh show sys clock"
-          - "tmsh list auth"
+    commands:
+      - "tmsh show sys clock"
+      - "tmsh list auth"
   register: result
 
 - name: Assert Run multiple commands
   assert:
-      that:
-          - result.stdout_lines|length == 2
+    that:
+      - result.stdout_lines|length == 2
 
 - name: Wait for something
   bigip_raw:
-      commands:
-          - "tmsh show sys clock"
-      wait_for:
-          - result[0] contains Sys::Clock
+    commands:
+      - "tmsh show sys clock"
+    wait_for:
+      - result[0] contains Sys::Clock
   register: result
 
 - name: Assert Wait for something
   assert:
-      that:
-          - result.stdout_lines|length == 1
+    that:
+      - result.stdout_lines|length == 1
 
 - name: Assert Run modify commands with a show command
   assert:
-      that:
-          - "'Sys::Clock' in result.stdout_lines[0][1]"
-          - result.stdout_lines|length == 1
+    that:
+      - "'Sys::Clock' in result.stdout_lines[0][1]"
+      - result.stdout_lines|length == 1
 
 - name: Run modify commands
   bigip_raw:
-      commands:
-          - "tmsh modify sys db setup.run value true"
-          - tmsh modify sys db setup.run value false
+    commands:
+      - "tmsh modify sys db setup.run value true"
+      - tmsh modify sys db setup.run value false
   register: result
 
 - name: Assert Run modify commands
   assert:
-      that:
-          - result.stdout_lines|length == 0
+    that:
+      - result.stdout_lines|length == 0
 
 - name: Run modify commands with a show command
   bigip_raw:
-      commands:
-          - "tmsh modify sys db setup.run value true"
-          - tmsh modify sys db setup.run value false
-          - "tmsh show sys clock"
+    commands:
+      - "tmsh modify sys db setup.run value true"
+      - tmsh modify sys db setup.run value false
+      - "tmsh show sys clock"
   register: result

--- a/test/integration/targets/bigip_remote_syslog/tasks/main.yaml
+++ b/test/integration/targets/bigip_remote_syslog/tasks/main.yaml
@@ -2,97 +2,97 @@
 
 - name: Create remote syslog
   bigip_remote_syslog:
-      remote_host: "{{ remote_host1 }}"
-      state: "present"
+    remote_host: "{{ remote_host1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create remote syslog
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create remote syslog - Idempotent check
   bigip_remote_syslog:
-      remote_host: "{{ remote_host1 }}"
-      state: "present"
+    remote_host: "{{ remote_host1 }}"
+    state: "present"
   register: result
 
 - name: Assert Create remote syslog - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Create another remote syslog
   bigip_remote_syslog:
-      remote_host: "{{ remote_host2 }}"
-      state: "present"
+    remote_host: "{{ remote_host2 }}"
+    state: "present"
   register: result
 
 - name: Assert Create another remote syslog
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create another remote syslog - Idempotent check
   bigip_remote_syslog:
-      remote_host: "{{ remote_host2 }}"
-      state: "present"
+    remote_host: "{{ remote_host2 }}"
+    state: "present"
   register: result
 
 - name: Assert Create another remote syslog - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove remote syslog
   bigip_remote_syslog:
-      remote_host: "{{ remote_host1 }}"
-      state: "absent"
+    remote_host: "{{ remote_host1 }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove remote syslog
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove remote syslog - Idempotent check
   bigip_remote_syslog:
-      remote_host: "{{ remote_host1 }}"
-      state: "absent"
+    remote_host: "{{ remote_host1 }}"
+    state: "absent"
   register: result
 
 - name: Assert Remove remote syslog - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove all remote syslog
   bigip_remote_syslog:
-      remote_host: "{{ item }}"
-      state: "absent"
+    remote_host: "{{ item }}"
+    state: "absent"
   register: result
   loop:
-      - "{{ remote_host1 }}"
-      - "{{ remote_host2 }}"
+    - "{{ remote_host1 }}"
+    - "{{ remote_host2 }}"
 
 - name: Assert Remove all remote syslog
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove all remote syslog - Idempotent check
   bigip_remote_syslog:
-      remote_host: "{{ item }}"
-      state: "absent"
+    remote_host: "{{ item }}"
+    state: "absent"
   register: result
   loop:
-      - "{{ remote_host1 }}"
-      - "{{ remote_host2 }}"
+    - "{{ remote_host1 }}"
+    - "{{ remote_host2 }}"
 
 - name: Assert Remove all remote syslog - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - import_tasks: issue-00405.yaml
   tags: issue-00405


### PR DESCRIPTION
…syslog modules along with 1 missed update in pool_member module.

- standardize on 2-space indents
- replace 'include: *.yaml' with 'import_tasks: *.yaml'
- replace 'with_items:' with 'loop:'
