### PR TITLE
Formatting and standards for snat_pool and snmp-related modules.

### DIFF
--- a/test/integration/bigip_snat_pool.yaml
+++ b/test/integration/bigip_snat_pool.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_snat_pool
+    - bigip_snat_pool

--- a/test/integration/bigip_snmp.yaml
+++ b/test/integration/bigip_snmp.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_snmp
+    - bigip_snmp

--- a/test/integration/bigip_snmp_community.yaml
+++ b/test/integration/bigip_snmp_community.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_snmp_community
+    - bigip_snmp_community

--- a/test/integration/bigip_snmp_trap.yaml
+++ b/test/integration/bigip_snmp_trap.yaml
@@ -50,11 +50,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_snmp_trap
+    - bigip_snmp_trap

--- a/test/integration/bigip_snmp_user.yaml
+++ b/test/integration/bigip_snmp_user.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_snmp_user
+    - bigip_snmp_user

--- a/test/integration/targets/bigip_snat_pool/defaults/main.yaml
+++ b/test/integration/targets/bigip_snat_pool/defaults/main.yaml
@@ -2,10 +2,10 @@
 
 snat_pool_name: my-snat-pool
 members_list:
-    - 10.10.10.10
-    - 20.20.20.20
+  - 10.10.10.10
+  - 20.20.20.20
 member_individual: 15.15.15.15
 member_append_list:
-    - 11.11.11.11
-    - 22.22.22.22
+  - 11.11.11.11
+  - 22.22.22.22
 member_append_individual: 33.33.33.33

--- a/test/integration/targets/bigip_snat_pool/tasks/main.yaml
+++ b/test/integration/targets/bigip_snat_pool/tasks/main.yaml
@@ -2,66 +2,66 @@
 
 - name: Create SNAT pool from list of members
   bigip_snat_pool:
-      name: "{{ snat_pool_name }}"
-      members: "{{ members_list }}"
+    name: "{{ snat_pool_name }}"
+    members: "{{ members_list }}"
   register: result
 
 - name: Assert Create SNAT pool from list of members
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create SNAT pool from list of members - Idempotent check
   bigip_snat_pool:
-      name: "{{ snat_pool_name }}"
-      members: "{{ members_list }}"
+    name: "{{ snat_pool_name }}"
+    members: "{{ members_list }}"
   register: result
 
 - name: Assert Create SNAT pool from list of members - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set SNAT pool to single member
   bigip_snat_pool:
-      name: "{{ snat_pool_name }}"
-      members: "{{ member_individual }}"
+    name: "{{ snat_pool_name }}"
+    members: "{{ member_individual }}"
   register: result
 
 - name: Assert Set SNAT pool to single member
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set SNAT pool to single member - Idempotent check
   bigip_snat_pool:
-      name: "{{ snat_pool_name }}"
-      members: "{{ member_individual }}"
+    name: "{{ snat_pool_name }}"
+    members: "{{ member_individual }}"
   register: result
 
 - name: Assert Set SNAT pool to single member - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete a SNAT pool
   bigip_snat_pool:
-      name: "{{ snat_pool_name }}"
-      state: absent
+    name: "{{ snat_pool_name }}"
+    state: absent
   register: result
 
 - name: Assert Delete a SNAT pool
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete a SNAT pool - Idempotent check
   bigip_snat_pool:
-      name: "{{ snat_pool_name }}"
-      state: absent
+    name: "{{ snat_pool_name }}"
+    state: absent
   register: result
 
 - name: Assert Delete a SNAT pool - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_snmp/tasks/main.yaml
+++ b/test/integration/targets/bigip_snmp/tasks/main.yaml
@@ -2,170 +2,170 @@
 
 - name: Set snmp contact
   bigip_snmp:
-      contact: "{{ contact1 }}"
+    contact: "{{ contact1 }}"
   register: result
 
 - name: Assert Set snmp contact
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp contact - Idempotent check
   bigip_snmp:
-      contact: "{{ contact1 }}"
+    contact: "{{ contact1 }}"
   register: result
 
 - name: Assert Set snmp contact - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Reset snmp contact
   bigip_snmp:
-      contact: "{{ contact2 }}"
+    contact: "{{ contact2 }}"
   register: result
 
 - name: Set snmp location
   bigip_snmp:
-      location: "{{ location1 }}"
+    location: "{{ location1 }}"
   register: result
 
 - name: Assert Set snmp location
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp location - Idempotent check
   bigip_snmp:
-      location: "{{ location1 }}"
+    location: "{{ location1 }}"
   register: result
 
 - name: Assert Set snmp location - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Reset snmp location
   bigip_snmp:
-      location: "{{ location2 }}"
+    location: "{{ location2 }}"
   register: result
 
 - name: Disable agent status traps
   bigip_snmp:
-      agent_status_traps: disabled
+    agent_status_traps: disabled
   register: result
 
 - name: Assert Disable agent status traps
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Disable agent status traps - Idempotent check
   bigip_snmp:
-      agent_status_traps: disabled
+    agent_status_traps: disabled
   register: result
 
 - name: Assert Disable agent status traps - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Enable agent status traps
   bigip_snmp:
-      agent_status_traps: enabled
+    agent_status_traps: enabled
   register: result
 
 - name: Assert Enable agent status traps
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Enable agent status traps - Idempotent check
   bigip_snmp:
-      agent_status_traps: enabled
+    agent_status_traps: enabled
   register: result
 
 - name: Assert Enable agent status traps - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Enable agent authentication traps
   bigip_snmp:
-      agent_authentication_traps: enabled
+    agent_authentication_traps: enabled
   register: result
 
 - name: Assert Enable agent authentication traps
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Enable agent authentication traps - Idempotent check
   bigip_snmp:
-      agent_authentication_traps: enabled
+    agent_authentication_traps: enabled
   register: result
 
 - name: Assert Enable agent authentication traps - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Disable agent authentication traps
   bigip_snmp:
-      agent_authentication_traps: disabled
+    agent_authentication_traps: disabled
   register: result
 
 - name: Assert Disable agent authentication traps
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Disable agent authentication traps - Idempotent check
   bigip_snmp:
-      agent_authentication_traps: disabled
+    agent_authentication_traps: disabled
   register: result
 
 - name: Assert Disable agent authentication traps - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Disable device warning traps
   bigip_snmp:
-      device_warning_traps: disabled
+    device_warning_traps: disabled
   register: result
 
 - name: Assert Disable device warning traps
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Disable device warning traps - Idempotent check
   bigip_snmp:
-      device_warning_traps: disabled
+    device_warning_traps: disabled
   register: result
 
 - name: Assert Disable device warning traps - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Enable device warning traps
   bigip_snmp:
-      device_warning_traps: enabled
+    device_warning_traps: enabled
   register: result
 
 - name: Assert Enable device warning traps
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Enable device warning traps - Idempotent check
   bigip_snmp:
-      device_warning_traps: enabled
+    device_warning_traps: enabled
   register: result
 
 - name: Assert Enable device warning traps - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_snmp_trap/tasks/main.yaml
+++ b/test/integration/targets/bigip_snmp_trap/tasks/main.yaml
@@ -2,11 +2,11 @@
 
 - name: Collect BIG-IP facts
   bigip_facts:
-      include: system_info
+    include: system_info
   register: result
 
-- include: v12.0.0.yaml
+- import_tasks: v12.0.0.yaml
   when: system_info.product_information.product_version < "12.1.0"
 
-- include: post-v12.yaml
+- import_tasks: post-v12.yaml
   when: system_info.product_information.product_version >= "12.1.0"

--- a/test/integration/targets/bigip_snmp_trap/tasks/post-v12.yaml
+++ b/test/integration/targets/bigip_snmp_trap/tasks/post-v12.yaml
@@ -2,186 +2,186 @@
 
 - name: Create snmp v1 trap
   bigip_snmp_trap:
-      community: "{{ community1 }}"
-      destination: "{{ destination1 }}"
-      name: "{{ trap_name1 }}"
-      network: "{{ network1 }}"
-      port: "{{ port1 }}"
-      snmp_version: "{{ version1 }}"
+    community: "{{ community1 }}"
+    destination: "{{ destination1 }}"
+    name: "{{ trap_name1 }}"
+    network: "{{ network1 }}"
+    port: "{{ port1 }}"
+    snmp_version: "{{ version1 }}"
   register: result
 
 - name: Assert Create snmp v1 trap
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create snmp v1 trap - Idempotent check
   bigip_snmp_trap:
-      community: "{{ community1 }}"
-      destination: "{{ destination1 }}"
-      name: "{{ trap_name1 }}"
-      network: "{{ network1 }}"
-      port: "{{ port1 }}"
-      snmp_version: "{{ version1 }}"
+    community: "{{ community1 }}"
+    destination: "{{ destination1 }}"
+    name: "{{ trap_name1 }}"
+    network: "{{ network1 }}"
+    port: "{{ port1 }}"
+    snmp_version: "{{ version1 }}"
   register: result
 
 - name: Assert Create snmp v1 trap - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp community
   bigip_snmp_trap:
-      community: "{{ community2 }}"
-      name: "{{ trap_name1 }}"
+    community: "{{ community2 }}"
+    name: "{{ trap_name1 }}"
   register: result
 
 - name: Assert Set snmp community
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp community - Idempotent check
   bigip_snmp_trap:
-      community: "{{ community2 }}"
-      name: "{{ trap_name1 }}"
+    community: "{{ community2 }}"
+    name: "{{ trap_name1 }}"
   register: result
 
 - name: Assert Set snmp community - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp destination to a hostname
   bigip_snmp_trap:
-      destination: "{{ destination2 }}"
-      name: "{{ trap_name1 }}"
+    destination: "{{ destination2 }}"
+    name: "{{ trap_name1 }}"
   register: result
 
 - name: Assert Set snmp destination to a hostname
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp destination to a hostname - Idempotent check
   bigip_snmp_trap:
-      destination: "{{ destination2 }}"
-      name: "{{ trap_name1 }}"
+    destination: "{{ destination2 }}"
+    name: "{{ trap_name1 }}"
   register: result
 
 - name: Assert Set snmp destination to a hostname - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp port
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      port: "{{ port2 }}"
+    name: "{{ trap_name1 }}"
+    port: "{{ port2 }}"
   register: result
 
 - name: Assert Set snmp port
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp port - Idempotent check
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      port: "{{ port2 }}"
+    name: "{{ trap_name1 }}"
+    port: "{{ port2 }}"
   register: result
 
 - name: Assert Set snmp port - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp network to default
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      network: "{{ network2 }}"
+    name: "{{ trap_name1 }}"
+    network: "{{ network2 }}"
   register: result
 
 - name: Assert Set snmp network to default
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp network to default - Idempotent check
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      network: "{{ network2 }}"
+    name: "{{ trap_name1 }}"
+    network: "{{ network2 }}"
   register: result
 
 - name: Assert Set snmp network to default - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp network to other
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      network: "{{ network3 }}"
+    name: "{{ trap_name1 }}"
+    network: "{{ network3 }}"
   register: result
 
 - name: Assert Set snmp network to other
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp network to other - Idempotent check
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      network: "{{ network3 }}"
+    name: "{{ trap_name1 }}"
+    network: "{{ network3 }}"
   register: result
 
 - name: Assert Set snmp network to other - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp version to 2c
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      snmp_version: "{{ version2 }}"
+    name: "{{ trap_name1 }}"
+    snmp_version: "{{ version2 }}"
   register: result
 
 - name: Assert Set snmp version to 2c
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp version to 2c - Idempotent check
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      snmp_version: "{{ version2 }}"
+    name: "{{ trap_name1 }}"
+    snmp_version: "{{ version2 }}"
   register: result
 
 - name: Assert Set snmp version to 2c - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete an snmp trap
   bigip_snmp_trap:
-      destination: "{{ destination2 }}"
-      name: "{{ trap_name1 }}"
-      state: absent
+    destination: "{{ destination2 }}"
+    name: "{{ trap_name1 }}"
+    state: absent
   register: result
 
 - name: Assert Delete an snmp trap
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete an snmp trap - Idempotent check
   bigip_snmp_trap:
-      destination: "{{ destination2 }}"
-      name: "{{ trap_name1 }}"
-      state: absent
+    destination: "{{ destination2 }}"
+    name: "{{ trap_name1 }}"
+    state: absent
   register: result
 
 - name: Assert Delete an snmp trap - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_snmp_trap/tasks/v12.0.0.yaml
+++ b/test/integration/targets/bigip_snmp_trap/tasks/v12.0.0.yaml
@@ -2,140 +2,140 @@
 
 - name: Create snmp v1 trap
   bigip_snmp_trap:
-      community: "{{ community1 }}"
-      destination: "{{ destination1 }}"
-      name: "{{ trap_name1 }}"
-      port: "{{ port1 }}"
-      snmp_version: "{{ version1 }}"
+    community: "{{ community1 }}"
+    destination: "{{ destination1 }}"
+    name: "{{ trap_name1 }}"
+    port: "{{ port1 }}"
+    snmp_version: "{{ version1 }}"
   register: result
 
 - name: Assert Create snmp v1 trap
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create snmp v1 trap - Idempotent check
   bigip_snmp_trap:
-      community: "{{ community1 }}"
-      destination: "{{ destination1 }}"
-      name: "{{ trap_name1 }}"
-      port: "{{ port1 }}"
-      snmp_version: "{{ version1 }}"
+    community: "{{ community1 }}"
+    destination: "{{ destination1 }}"
+    name: "{{ trap_name1 }}"
+    port: "{{ port1 }}"
+    snmp_version: "{{ version1 }}"
   register: result
 
 - name: Assert Create snmp v1 trap - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp community
   bigip_snmp_trap:
-      community: "{{ community2 }}"
-      name: "{{ trap_name1 }}"
+    community: "{{ community2 }}"
+    name: "{{ trap_name1 }}"
   register: result
 
 - name: Assert Set snmp community
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp community - Idempotent check
   bigip_snmp_trap:
-      community: "{{ community2 }}"
-      name: "{{ trap_name1 }}"
+    community: "{{ community2 }}"
+    name: "{{ trap_name1 }}"
   register: result
 
 - name: Assert Set snmp community - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp destination to a hostname
   bigip_snmp_trap:
-      destination: "{{ destination2 }}"
-      name: "{{ trap_name1 }}"
+    destination: "{{ destination2 }}"
+    name: "{{ trap_name1 }}"
   register: result
 
 - name: Assert Set snmp destination to a hostname
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp destination to a hostname - Idempotent check
   bigip_snmp_trap:
-      destination: "{{ destination2 }}"
-      name: "{{ trap_name1 }}"
+    destination: "{{ destination2 }}"
+    name: "{{ trap_name1 }}"
   register: result
 
 - name: Assert Set snmp destination to a hostname - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp port
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      port: "{{ port2 }}"
+    name: "{{ trap_name1 }}"
+    port: "{{ port2 }}"
   register: result
 
 - name: Assert Set snmp port
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp port - Idempotent check
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      port: "{{ port2 }}"
+    name: "{{ trap_name1 }}"
+    port: "{{ port2 }}"
   register: result
 
 - name: Assert Set snmp port - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set snmp version to 2c
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      snmp_version: "{{ version2 }}"
+    name: "{{ trap_name1 }}"
+    snmp_version: "{{ version2 }}"
   register: result
 
 - name: Assert Set snmp version to 2c
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set snmp version to 2c - Idempotent check
   bigip_snmp_trap:
-      name: "{{ trap_name1 }}"
-      snmp_version: "{{ version2 }}"
+    name: "{{ trap_name1 }}"
+    snmp_version: "{{ version2 }}"
   register: result
 
 - name: Assert Set snmp version to 2c - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Delete an snmp trap
   bigip_snmp_trap:
-      destination: "{{ destination2 }}"
-      name: "{{ trap_name1 }}"
-      state: absent
+    destination: "{{ destination2 }}"
+    name: "{{ trap_name1 }}"
+    state: absent
   register: result
 
 - name: Assert Delete an snmp trap
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Delete an snmp trap - Idempotent check
   bigip_snmp_trap:
-      destination: "{{ destination2 }}"
-      name: "{{ trap_name1 }}"
-      state: absent
+    destination: "{{ destination2 }}"
+    name: "{{ trap_name1 }}"
+    state: absent
   register: result
 
 - name: Assert Delete an snmp trap - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed


### PR DESCRIPTION
- 2-space indenting
- replace 'include: *.yaml' with 'import_tasks: *.yaml'