### PR TITLE
Standards and formatting for integration tests in bigip_software_* modules.

### DIFF
--- a/test/integration/bigip_software.yaml
+++ b/test/integration/bigip_software.yaml
@@ -63,11 +63,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_software
+    - bigip_software

--- a/test/integration/bigip_software_facts.yaml
+++ b/test/integration/bigip_software_facts.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_software_facts
+    - bigip_software_facts

--- a/test/integration/bigip_software_update.yaml
+++ b/test/integration/bigip_software_update.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_software_update
+    - bigip_software_update

--- a/test/integration/targets/bigip_software/tasks/local.yaml
+++ b/test/integration/targets/bigip_software/tasks/local.yaml
@@ -2,236 +2,236 @@
 
 - name: Upload 12.1.1 base image
   bigip_software:
-      software: "{{ iso_base }}"
-      state: present
+    software: "{{ iso_base }}"
+    state: present
   register: result
 
 - name: Assert Upload 12.1.1 base image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Upload 12.1.1 base image - Idempotent check
   bigip_software:
-      software: "{{ iso_base }}"
-      state: present
+    software: "{{ iso_base }}"
+    state: present
   register: result
 
 - name: Assert Upload 12.0.0 base image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Upload 12.1.1 HF1 hotfix image
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      state: present
+    hotfix: "{{ iso_hotfix }}"
+    state: present
   register: result
 
 - name: Assert Upload 12.1.1 HF1 hotfix image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Upload 12.1.1 HF1 hotfix image - Idempotent check
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      state: present
+    hotfix: "{{ iso_hotfix }}"
+    state: present
   register: result
 
 - name: Assert Upload 12.1.1 HF1 hotfix image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove uploaded 12.1.1 base image
   bigip_software:
-      software: "{{ iso_base }}"
-      state: absent
+    software: "{{ iso_base }}"
+    state: absent
   register: result
 
 - name: Assert Remove uploaded 12.1.1 base image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove uploaded 12.1.1 base image - Idempotent check
   bigip_software:
-      software: "{{ iso_base }}"
-      state: absent
+    software: "{{ iso_base }}"
+    state: absent
   register: result
 
 - name: Assert Remove uploaded 12.1.1 base image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove uploaded 12.1.1 HF1 hotfix image
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      state: absent
+    hotfix: "{{ iso_hotfix }}"
+    state: absent
   register: result
 
 - name: Assert Remove uploaded 12.1.1 HF1 hotfix image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove uploaded 12.1.1 HF1 hotfix image - Idempotent check
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      state: absent
+    hotfix: "{{ iso_hotfix }}"
+    state: absent
   register: result
 
 - name: Assert Remove uploaded 12.1.1 HF1 hotfix image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Upload base image and hotfix
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      software: "{{ iso_base }}"
-      state: present
+    hotfix: "{{ iso_hotfix }}"
+    software: "{{ iso_base }}"
+    state: present
   register: result
 
 - name: Assert Upload base image and hotfix
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Upload base image and hotfix - Idempotent check
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      software: "{{ iso_base }}"
-      state: present
+    hotfix: "{{ iso_hotfix }}"
+    software: "{{ iso_base }}"
+    state: present
   register: result
 
 - name: Assert Upload base image and hotfix - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove uploaded base image and hotfix
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      software: "{{ iso_base }}"
-      state: absent
+    hotfix: "{{ iso_hotfix }}"
+    software: "{{ iso_base }}"
+    state: absent
   register: result
 
 - name: Assert Remove uploaded base image and hotfix
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove uploaded base image and hotfix - Idempotent check
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      software: "{{ iso_base }}"
-      state: absent
+    hotfix: "{{ iso_hotfix }}"
+    software: "{{ iso_base }}"
+    state: absent
   register: result
 
 - name: Assert Remove uploaded base image and hotfix - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Install (upload, install) base image
   bigip_software:
-      software: "{{ iso_base }}"
-      state: installed
-      volume: "{{ volume_new }}"
+    software: "{{ iso_base }}"
+    state: installed
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Install (upload, install) base image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Install (upload, install) base image - Idempotent check
   bigip_software:
-      software: "{{ iso_base }}"
-      state: installed
-      volume: "{{ volume_new }}"
+    software: "{{ iso_base }}"
+    state: installed
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Install (upload, install) base image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Install (upload, install) base image and hotfix
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      software: "{{ iso_base }}"
-      state: installed
-      volume: "{{ volume_new }}"
+    hotfix: "{{ iso_hotfix }}"
+    software: "{{ iso_base }}"
+    state: installed
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Install (upload, install) base image and hotfix
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Install (upload, install) base image and hotfix - Idempotent check
   bigip_software:
-      hotfix: "{{ iso_hotfix }}"
-      software: "{{ iso_base }}"
-      state: installed
-      volume: "{{ volume_new }}"
+    hotfix: "{{ iso_hotfix }}"
+    software: "{{ iso_base }}"
+    state: installed
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Install (upload, install) base image and hotfix - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Activate (upload, install, reboot) base image
   bigip_software:
-      software: "{{ iso_base }}"
-      state: activated
-      volume: "{{ volume_new }}"
+    software: "{{ iso_base }}"
+    state: activated
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Activate (upload, install, reboot) base image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Activate (upload, install, reboot) base image and hotfix - Idempotent check
   bigip_software:
-      software: "{{ iso_base }}"
-      state: activated
-      volume: "{{ volume_new }}"
+    software: "{{ iso_base }}"
+    state: activated
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Activate (upload, install, reboot) base image and hotfix - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Activate (upload, install, reboot, reuse_inactive_volume) base image and hotfix
   bigip_software:
-      reuse_inactive_volume: True
-      hotfix: "{{ iso_hostfix }}"
-      software: "{{ iso_base }}"
-      state: activated
+    reuse_inactive_volume: True
+    hotfix: "{{ iso_hostfix }}"
+    software: "{{ iso_base }}"
+    state: activated
   register: result
 
 - name: Assert Activate (upload, install, reboot, reuse_inactive_volume) base image and hotfix
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Activate (upload, install, reboot, reuse_inactive_volume) base image and hotfix - Idempotent check
   bigip_software:
-      reuse_inactive_volume: True
-      hotfix: "{{ iso_hostfix }}"
-      software: "{{ iso_base }}"
-      state: activated
+    reuse_inactive_volume: True
+    hotfix: "{{ iso_hostfix }}"
+    software: "{{ iso_base }}"
+    state: activated
   register: result
 
 - name: Assert Activate (upload, install, reboot, reuse_inactive_volume) base image and hotfix - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_software/tasks/main.yaml
+++ b/test/integration/targets/bigip_software/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
 
-- include: setup.yaml
+- import_tasks: setup.yaml
 
-- include: remote.yaml
+- import_tasks: remote.yaml
   when: "limit_to in ['*', 'remote']"
 
-- include: local.yaml
+- import_tasks: local.yaml
   when: "limit_to in ['*', 'local']"

--- a/test/integration/targets/bigip_software/tasks/remote.yaml
+++ b/test/integration/targets/bigip_software/tasks/remote.yaml
@@ -273,7 +273,7 @@
 
 - name: Assert Activate (download, install, reboot) base image - Idempotent check
   assert:
-     that:
+    that:
       - not result|changed
 
 - name: Activate (download, install, reboot, reuse_inactive_volume) base image and hotfix

--- a/test/integration/targets/bigip_software/tasks/remote.yaml
+++ b/test/integration/targets/bigip_software/tasks/remote.yaml
@@ -2,312 +2,312 @@
 
 - name: Download 12.1.2 base image
   bigip_software:
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      state: present
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    state: present
   register: result
 
 - name: Assert Download 12.1.2 base image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Download 12.1.2 base image - Idempotent check
   bigip_software:
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_img }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: present
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_img }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: present
   register: result
 
 - name: Assert Download 12.1.2 base image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Download 12.1.2 HF1 hotfix image
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      hotfix_md5sum: "{{ hotfix_md5 }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: present
+    hotfix: "{{ hotfix_link }}"
+    hotfix_md5sum: "{{ hotfix_md5 }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: present
   register: result
 
 - name: Assert Download 12.1.2 HF1 hotfix image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Download 12.1.2 HF1 hotfix image - Idempotent check
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      hotfix_md5sum: "{{ hotfix_md5 }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: present
+    hotfix: "{{ hotfix_link }}"
+    hotfix_md5sum: "{{ hotfix_md5 }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: present
   register: result
 
 - name: Assert Download 12.1.2 HF1 hotfix image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove downloaded 12.1.2 base image
   bigip_software:
-      software: "{{ image_link }}"
-      build: "{{ build_img }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: absent
+    software: "{{ image_link }}"
+    build: "{{ build_img }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: absent
   register: result
 
 - name: Assert Remove downloaded 12.1.2 base image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove downloaded 12.1.2 base image - Idempotent check
   bigip_software:
-      software: "{{ image_link }}"
-      build: "{{ build_img }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: absent
+    software: "{{ image_link }}"
+    build: "{{ build_img }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: absent
   register: result
 
 - name: Assert Remove downloaded 12.1.2 base image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove uploaded 12.1.2 HF1 hotfix image
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: absent
+    hotfix: "{{ hotfix_link }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: absent
   register: result
 
 - name: Assert Remove downloaded 12.1.2 HF1 hotfix image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove downloaded 12.1.2 HF1 hotfix image - Idempotent check
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: absent
+    hotfix: "{{ hotfix_link }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: absent
   register: result
 
 - name: Assert Remove downloaded 12.1.2 HF1 hotfix image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Download base image and hotfix
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      hotfix_md5sum: "{{ hotfix_md5 }}"
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: present
+    hotfix: "{{ hotfix_link }}"
+    hotfix_md5sum: "{{ hotfix_md5 }}"
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: present
   register: result
 
 - name: Assert Download base image and hotfix
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Download base image and hotfix - Idempotent check
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      hotfix_md5sum: "{{ hotfix_md5 }}"
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: present
+    hotfix: "{{ hotfix_link }}"
+    hotfix_md5sum: "{{ hotfix_md5 }}"
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: present
   register: result
 
 - name: Assert Download base image and hotfix - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove downloaded base image and hotfix
   bigip_software:
-      hotfix: "{{ hotfix_link}}"
-      software: "{{ image_link}}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: absent
+    hotfix: "{{ hotfix_link}}"
+    software: "{{ image_link}}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: absent
   register: result
 
 - name: Assert Remove downloaded base image and hotfix
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove downloaded base image and hotfix - Idempotent check
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      software: "{{ image_link }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: absent
+    hotfix: "{{ hotfix_link }}"
+    software: "{{ image_link }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: absent
   register: result
 
 - name: Assert Remove downloaded base image and hotfix - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Install (download, install) base image
   bigip_software:
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_img }}"
-      version: "{{ version }}"
-      remote_src: yes
-      volume: "{{ volume_new }}"
-      state: installed
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_img }}"
+    version: "{{ version }}"
+    remote_src: yes
+    volume: "{{ volume_new }}"
+    state: installed
   register: result
 
 - name: Assert Install (download, install) base image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Install (download, install) base image - Idempotent check
   bigip_software:
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_img }}"
-      version: "{{ version }}"
-      remote_src: yes
-      volume: "{{ volume_new }}"
-      state: installed
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_img }}"
+    version: "{{ version }}"
+    remote_src: yes
+    volume: "{{ volume_new }}"
+    state: installed
   register: result
 - name: Assert Install (download, install) base image - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Install (download, install) base image and hotfix
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      hotfix_md5sum: "{{ hotfix_md5 }}"
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: installed
-      volume: "{{ volume_new }}"
+    hotfix: "{{ hotfix_link }}"
+    hotfix_md5sum: "{{ hotfix_md5 }}"
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: installed
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Install (download, install) base image and hotfix
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Install (download, install) base image and hotfix - Idempotent check
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      hotfix_md5sum: "{{ hotfix_md5 }}"
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: installed
-      volume: "{{ volume_new }}"
+    hotfix: "{{ hotfix_link }}"
+    hotfix_md5sum: "{{ hotfix_md5 }}"
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: installed
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Install (download, install) base image and hotfix - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Activate (download, install, reboot) base image
   bigip_software:
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_img }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: activated
-      volume: "{{ volume_new }}"
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_img }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: activated
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Activate (download, install, reboot) base image
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Activate (download, install, reboot) base image - Idempotent check
   bigip_software:
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_img }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: activated
-      volume: "{{ volume_new }}"
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_img }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: activated
+    volume: "{{ volume_new }}"
   register: result
 
 - name: Assert Activate (download, install, reboot) base image - Idempotent check
   assert:
-      that:
-          - not result|changed
+     that:
+      - not result|changed
 
 - name: Activate (download, install, reboot, reuse_inactive_volume) base image and hotfix
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      hotfix_md5sum: "{{ hotfix_md5 }}"
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: activated
-      reuse_inactive_volume: True
+    hotfix: "{{ hotfix_link }}"
+    hotfix_md5sum: "{{ hotfix_md5 }}"
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: activated
+    reuse_inactive_volume: True
   register: result
 
 - name: Assert Activate (download, install, reboot, reuse_inactive_volume) base image and hotfix
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Activate (download, install, reboot, reuse_inactive_volume) base image and hotfix - Idempotent check
   bigip_software:
-      hotfix: "{{ hotfix_link }}"
-      hotfix_md5sum: "{{ hotfix_md5 }}"
-      software: "{{ image_link }}"
-      software_md5sum: "{{ image_md5 }}"
-      build: "{{ build_hf }}"
-      version: "{{ version }}"
-      remote_src: yes
-      state: activated
-      reuse_inactive_volume: True
+    hotfix: "{{ hotfix_link }}"
+    hotfix_md5sum: "{{ hotfix_md5 }}"
+    software: "{{ image_link }}"
+    software_md5sum: "{{ image_md5 }}"
+    build: "{{ build_hf }}"
+    version: "{{ version }}"
+    remote_src: yes
+    state: activated
+    reuse_inactive_volume: True
   register: result
 
 - name: Assert Activate (download, install, reboot, reuse_inactive_volume) base image and hotfix - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_software/tasks/setup.yaml
+++ b/test/integration/targets/bigip_software/tasks/setup.yaml
@@ -2,15 +2,15 @@
 
 - name: Check that default values have been changed
   assert:
-      that:
-          - iso_base != "/path/to/iso/BIGIP-12.1.1.0.0.184.iso"
-          - iso_hotfix != "/path/to/iso/Hotfix-BIGIP-12.1.1.1.0.196-HF1.iso"
+    that:
+      - iso_base != "/path/to/iso/BIGIP-12.1.1.0.0.184.iso"
+      - iso_hotfix != "/path/to/iso/Hotfix-BIGIP-12.1.1.1.0.196-HF1.iso"
 
 - name: Check that default values have been changed
   assert:
-      that:
-          - image_link != "http://fake.com/12.1.2.iso"
-          - hotfix_link != "http://fake.com/12.1.2-HF1.iso"
-          - image_md5 != "http://fake.com/12.1.2.iso.md5"
-          - hotfix_md5 != "http://fake.com/12.1.2-HF1.iso.md5"
+    that:
+      - image_link != "http://fake.com/12.1.2.iso"
+      - hotfix_link != "http://fake.com/12.1.2-HF1.iso"
+      - image_md5 != "http://fake.com/12.1.2.iso.md5"
+      - hotfix_md5 != "http://fake.com/12.1.2-HF1.iso.md5"
   when: "limit_to in ['*', 'remote']"

--- a/test/integration/targets/bigip_software_facts/tasks/main.yaml
+++ b/test/integration/targets/bigip_software_facts/tasks/main.yaml
@@ -5,11 +5,11 @@
 
 - name: Assert Get all software facts
   assert:
-      that:
-          - result|changed
-          - "'images' in result"
-          - "'hotfixes' in result"
-          - "'volumes' in result"
+    that:
+      - result|changed
+      - "'images' in result"
+      - "'hotfixes' in result"
+      - "'volumes' in result"
 
 - name: Get base image ISOs facts
   bigip_software_facts:
@@ -18,11 +18,11 @@
 
 - name: Assert Get base image ISOs facts
   assert:
-      that:
-          - result|changed
-          - "'images' in result"
-          - "'hotfixes' not in result"
-          - "'volumes' not in result"
+    that:
+      - result|changed
+      - "'images' in result"
+      - "'hotfixes' not in result"
+      - "'volumes' not in result"
 
 - name: Get hotfix ISOs facts
   bigip_software_facts:
@@ -31,11 +31,11 @@
 
 - name: Assert Get hotfix ISOs facts
   assert:
-      that:
-          - result|changed
-          - "'images' not in result"
-          - "'hotfixes' in result"
-          - "'volumes' not in result"
+    that:
+      - result|changed
+      - "'images' not in result"
+      - "'hotfixes' in result"
+      - "'volumes' not in result"
 
 - name: Get volumes facts
   bigip_software_facts:
@@ -44,11 +44,11 @@
 
 - name: Assert Get volumes facts
   assert:
-      that:
-          - result|changed
-          - "'images' not in result"
-          - "'hotfixes' not in result"
-          - "'volumes' in result"
+    that:
+      - result|changed
+      - "'images' not in result"
+      - "'hotfixes' not in result"
+      - "'volumes' in result"
 
 - name: Get volumes facts with filter
   bigip_software_facts:
@@ -58,10 +58,10 @@
 
 - name: Assert Get volumes facts with filter
   assert:
-      that:
-          - result|changed
-          - result.volumes|length == 1
-          - "'volumes' in result"
+    that:
+      - result|changed
+      - result.volumes|length == 1
+      - "'volumes' in result"
 
 - name: Get images facts with bad filter
   bigip_software_facts:
@@ -72,5 +72,5 @@
 
 - name: Assert Get images facts with bad filter
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed


### PR DESCRIPTION
- Standardize on 2-space indents
- Replace any 'include: *.yaml' with 'import_tasks: *.yaml'