### PR TITLE
Standards and formatting for integrated tests in bigip_ucs* and bigip_user* modules.

### DIFF
--- a/test/integration/bigip_ucs.yaml
+++ b/test/integration/bigip_ucs.yaml
@@ -51,11 +51,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_ucs
+    - bigip_ucs

--- a/test/integration/bigip_ucs_fetch.yaml
+++ b/test/integration/bigip_ucs_fetch.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_ucs_fetch
+    - bigip_ucs_fetch

--- a/test/integration/bigip_user.yaml
+++ b/test/integration/bigip_user.yaml
@@ -50,11 +50,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_user
+    - bigip_user

--- a/test/integration/bigip_user_facts.yaml
+++ b/test/integration/bigip_user_facts.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_user_facts
+    - bigip_user_facts

--- a/test/integration/targets/bigip_ucs/tasks/main.yaml
+++ b/test/integration/targets/bigip_ucs/tasks/main.yaml
@@ -1,92 +1,92 @@
 ---
 
-#include: setup.yaml
+#import_tasks: setup.yaml
 
 - name: Upload UCS file
   bigip_ucs:
-      ucs: "{{ role_path }}/files/{{ ucs_name }}"
+    ucs: "{{ role_path }}/files/{{ ucs_name }}"
   register: result
 
 - name: Assert Upload UCS file
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Upload UCS file - Idempotent check
   bigip_ucs:
-      ucs: "{{ role_path }}/files/{{ ucs_name }}"
+    ucs: "{{ role_path }}/files/{{ ucs_name }}"
   register: result
 
 - name: Assert Upload UCS file - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Force upload UCS file
   bigip_ucs:
-      ucs: "{{ role_path }}/files/{{ ucs_name }}"
-      force: yes
+    ucs: "{{ role_path }}/files/{{ ucs_name }}"
+    force: yes
   register: result
 
 - name: Assert Force upload UCS file
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Install an uploaded UCS file
   bigip_ucs:
-      ucs: "{{ role_path }}/files/{{ ucs_name }}"
-      state: installed
+    ucs: "{{ role_path }}/files/{{ ucs_name }}"
+    state: installed
   register: result
 
 - name: Assert Install an uploaded UCS file
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Install an uploaded UCS file again - expected not idempotent
   bigip_ucs:
-      ucs: "{{ role_path }}/files/{{ ucs_name }}"
-      state: installed
+    ucs: "{{ role_path }}/files/{{ ucs_name }}"
+    state: installed
   register: result
 
 - name: Assert Install an uploaded UCS file again - expected not idempotent
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove uploaded UCS file
   bigip_ucs:
-      ucs: "{{ role_path }}/files/{{ ucs_name }}"
-      state: absent
+    ucs: "{{ role_path }}/files/{{ ucs_name }}"
+    state: absent
   register: result
 
 - name: Assert Remove uploaded UCS file
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove uploaded UCS file - Idempotent check
   bigip_ucs:
-      ucs: "{{ role_path }}/files/{{ ucs_name }}"
-      state: absent
+    ucs: "{{ role_path }}/files/{{ ucs_name }}"
+    state: absent
   register: result
 
 - name: Assert Remove uploaded UCS file - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Install a UCS file, no initial upload
   bigip_ucs:
-      ucs: "{{ role_path }}/files/{{ ucs_name }}"
-      state: installed
+    ucs: "{{ role_path }}/files/{{ ucs_name }}"
+    state: installed
   register: result
 
 - name: Remove uploaded UCS file
   bigip_ucs:
-      ucs: "{{ role_path }}/files/{{ ucs_name }}"
-      state: absent
+    ucs: "{{ role_path }}/files/{{ ucs_name }}"
+    state: absent
   register: result
 
-#- include: teardown.yaml
+#- import_tasks: teardown.yaml

--- a/test/integration/targets/bigip_ucs/tasks/setup.yaml
+++ b/test/integration/targets/bigip_ucs/tasks/setup.yaml
@@ -2,8 +2,8 @@
 
 - name: Get temporary file for fetching UCS
   tempfile:
-      state: file
-      suffix: temp
+    state: file
+    suffix: temp
   register: result
 
 - name: Save a UCS file locally for later usage

--- a/test/integration/targets/bigip_ucs_fetch/tasks/main.yaml
+++ b/test/integration/targets/bigip_ucs_fetch/tasks/main.yaml
@@ -2,99 +2,99 @@
 
 - name: Create a UCS
   bigip_ucs_fetch:
-      dest: "/tmp/{{ ucs_name }}"
-      src: "{{ ucs_name }}"
+    dest: "/tmp/{{ ucs_name }}"
+    src: "{{ ucs_name }}"
   register: result
 
 - name: Assert Create a UCS
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create the same UCS, default force
   bigip_ucs_fetch:
-      dest: "/tmp/{{ ucs_name }}"
-      src: "{{ ucs_name }}"
+    dest: "/tmp/{{ ucs_name }}"
+    src: "{{ ucs_name }}"
   register: result
 
 - name: Assert Create the same UCS, default force
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create a UCS, do not force
   bigip_ucs_fetch:
-      dest: "/tmp/{{ ucs_name_1 }}"
-      force: no
-      src: "{{ ucs_name }}"
+    dest: "/tmp/{{ ucs_name_1 }}"
+    force: no
+    src: "{{ ucs_name }}"
   register: result
 
 - name: Assert Create a UCS, do not force
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create a UCS, leave a backup
   bigip_ucs_fetch:
-      backup: yes
-      dest: "/tmp/{{ ucs_name_1 }}"
-      src: "{{ ucs_name }}"
+    backup: yes
+    dest: "/tmp/{{ ucs_name_1 }}"
+    src: "{{ ucs_name }}"
   register: result
 
 - name: Assert Create a UCS, leave a backup
   assert:
-      that:
-          - result|changed
-          - "'backup_file' in result"
+    that:
+      - result|changed
+      - "'backup_file' in result"
 
 - name: Remove backup UCS
   file:
-      path: "{{ result['backup_file'] }}"
-      state: absent
+    path: "{{ result['backup_file'] }}"
+    state: absent
 
 - name: Fetch a missing UCS
   bigip_ucs_fetch:
-      create_on_missing: no
-      dest: "/tmp/{{ ucs_missing }}"
-      src: "{{ ucs_missing }}"
+    create_on_missing: no
+    dest: "/tmp/{{ ucs_missing }}"
+    src: "{{ ucs_missing }}"
   ignore_errors: true
   register: result
 
 - name: Assert Error on fetching a missing UCS
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Error on fetching a missing UCS
   bigip_ucs_fetch:
-      fail_on_missing: yes
-      dest: "/tmp/{{ ucs_missing }}"
-      src: "{{ ucs_missing }}"
+    fail_on_missing: yes
+    dest: "/tmp/{{ ucs_missing }}"
+    src: "{{ ucs_missing }}"
   ignore_errors: true
   register: result
 
 - name: Assert Error on fetching a missing UCS
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Create a UCS with encryption password
   bigip_ucs_fetch:
-      dest: "/tmp/{{ ucs_missing }}"
-      encryption_password: admin
-      src: "{{ ucs_missing }}"
+    dest: "/tmp/{{ ucs_missing }}"
+    encryption_password: admin
+    src: "{{ ucs_missing }}"
   register: result
 
 - name: Assert Create a UCS with encryption password
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove backups
   file:
-      path: "{{ item }}"
-      state: absent
-  with_items:
-      - "/tmp/{{ ucs_missing }}"
-      - "/tmp/{{ ucs_name_1 }}"
-      - "/tmp/{{ ucs_name }}"
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "/tmp/{{ ucs_missing }}"
+    - "/tmp/{{ ucs_name_1 }}"
+    - "/tmp/{{ ucs_name }}"

--- a/test/integration/targets/bigip_user/defaults/main.yaml
+++ b/test/integration/targets/bigip_user/defaults/main.yaml
@@ -3,13 +3,13 @@
 username_credential: johnd
 password_credential: password
 partition_access1:
-    - all:admin
-    - Common:guest
-    - Common:operator
+  - all:admin
+  - Common:guest
+  - Common:operator
 partition_access2:
-    - all:admin
-    - Common:operator
+  - all:admin
+  - Common:operator
 partition_access3:
-    - foo:operator
+  - foo:operator
 partition: foo
 full_name: John Doe

--- a/test/integration/targets/bigip_user/tasks/issue-00113.yaml
+++ b/test/integration/targets/bigip_user/tasks/issue-00113.yaml
@@ -2,50 +2,50 @@
 
 - name: Issue 00113 - Create an admin user
   bigip_user:
-      partition_access:
-        - all:admin
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
-      update_password: on_create
+    partition_access:
+      - all:admin
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    update_password: on_create
   register: result
 
 - name: Issue 00113 - Assert Create an admin user
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Issue 00113 - Create an admin user - Idempotent check
   bigip_user:
-      partition_access:
-        - all:admin
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
-      update_password: on_create
+    partition_access:
+      - all:admin
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    update_password: on_create
   register: result
 
 - name: Issue 00113 - Assert Create an admin user - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Issue 00113 - Remove the admin user
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      state: absent
+    username_credential: "{{ username_credential }}"
+    state: absent
   register: result
 
 - name: Issue 00113 - Assert Remove the admin user
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Issue 00113 - Remove the admin user - Idempotent check
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      state: absent
+    username_credential: "{{ username_credential }}"
+    state: absent
   register: result
 
 - name: Issue 00113 - Assert Remove the admin user - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_user/tasks/issue-00276.yaml
+++ b/test/integration/targets/bigip_user/tasks/issue-00276.yaml
@@ -2,32 +2,32 @@
 
 - name: Issue 00276 - Turn on tmsh shell for admin user - Issue 276
   bigip_user:
-      server: "{{ ansible_host }}"
-      server_port: "{{ bigip_port }}"
-      user: "{{ bigip_username }}"
-      password: "{{ bigip_password }}"
-      validate_certs: "{{ validate_certs }}"
-      username_credential: admin
-      shell: bash
+    server: "{{ ansible_host }}"
+    server_port: "{{ bigip_port }}"
+    user: "{{ bigip_username }}"
+    password: "{{ bigip_password }}"
+    validate_certs: "{{ validate_certs }}"
+    username_credential: admin
+    shell: bash
   register: result
 
 - name: Issue 00276 - Assert Turn on tmsh shell for admin user - Issue 276
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Issue 00276 - Turn on tmsh shell for admin user - Issue 276 - Idempotent check
   bigip_user:
-      server: "{{ ansible_host }}"
-      server_port: "{{ bigip_port }}"
-      user: "{{ bigip_username }}"
-      password: "{{ bigip_password }}"
-      validate_certs: "{{ validate_certs }}"
-      username_credential: admin
-      shell: bash
+    server: "{{ ansible_host }}"
+    server_port: "{{ bigip_port }}"
+    user: "{{ bigip_username }}"
+    password: "{{ bigip_password }}"
+    validate_certs: "{{ validate_certs }}"
+    username_credential: admin
+    shell: bash
   register: result
 
 - name: Issue 00276 - Assert Turn on tmsh shell for admin user - Issue 276 - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed

--- a/test/integration/targets/bigip_user/tasks/issue-00310.yaml
+++ b/test/integration/targets/bigip_user/tasks/issue-00310.yaml
@@ -2,23 +2,23 @@
 
 - name: Issue 00310 - Change root user password
   bigip_user:
-      username_credential: root
-      password_credential: foobar
+    username_credential: root
+    password_credential: foobar
   register: result
 
 - name: Issue 00310 - Assert Change root user password
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Issue 00310 - Change root user password - Idempotent check
   bigip_user:
-      username_credential: root
-      password_credential: foobar
+    username_credential: root
+    password_credential: foobar
   register: result
 
 # NOTE: This module is not able to support root password idempotency
 - name: Issue 00310 - Assert Change root user password - Idempotent check
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed

--- a/test/integration/targets/bigip_user/tasks/main.yaml
+++ b/test/integration/targets/bigip_user/tasks/main.yaml
@@ -1,249 +1,248 @@
 ---
 
-- include: setup.yaml
+- import_tasks: setup.yaml
 
 - name: Create user, no password
   bigip_user:
-      partition_access:
-        - Common:guest
-      username_credential: testusernopass
+    partition_access:
+      - Common:guest
+    username_credential: testusernopass
   register: result
 
 - name: Assert create user, no password
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create user, no password - Idempotent check
   bigip_user:
-      partition_access:
-        - Common:guest
-      username_credential: testusernopass
+    partition_access:
+      - Common:guest
+    username_credential: testusernopass
   register: result
 
 - name: Assert create user, no password - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Create user
   bigip_user:
-      partition_access:
-        - Common:guest
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
-      update_password: on_create
+    partition_access:
+      - Common:guest
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    update_password: on_create
   register: result
 
 - name: Assert Create user
   assert:
-      that:
-          - result|changed
-
+    that:
+      - result|changed
 
 - name: Create user - Idempotent check
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
-      update_password: on_create
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    update_password: on_create
   register: result
 
 - name: Assert Create user - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 # This is very specific to bigip user, here we always update password if
 # password_credential is present, as default value for password_update is
 # set to always.
 - name: Update user password
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
   register: result
 
 - name: Assert update user password
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 # We should see password not updating here
 - name: Update user password password_update set to on_create
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
-      update_password: on_create
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    update_password: on_create
   register: result
 
 - name: Assert Update user password password_update set to on_create
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Update user partition access
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      partition_access:
-        - Common:manager
+    username_credential: "{{ username_credential }}"
+    partition_access:
+      - Common:manager
   register: result
 
 - name: Assert Update user partition access
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Update user partition access - Idempotent check
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      partition_access:
-        - Common:manager
+    username_credential: "{{ username_credential }}"
+    partition_access:
+      - Common:manager
   register: result
 
 - name: Assert Update user partition access - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Update user full name
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      full_name: "{{ full_name }}"
+    username_credential: "{{ username_credential }}"
+    full_name: "{{ full_name }}"
   register: result
 
 - name: Assert Update user full name
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Update user full name - Idempotent check
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      full_name: "{{ full_name }}"
+    username_credential: "{{ username_credential }}"
+    full_name: "{{ full_name }}"
   register: result
 
 - name: Assert Update user full name - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Update user shell to tmsh
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      shell: tmsh
+    username_credential: "{{ username_credential }}"
+    shell: tmsh
   register: result
 
 - name: Assert Update user shell to tmsh
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Update user shell to tmsh - Idempotent check
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      shell: tmsh
+    username_credential: "{{ username_credential }}"
+    shell: tmsh
   register: result
 
 - name: Assert Update user shell to tmsh - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 # This should fail because the user does not have the appropriate role
 - name: Update user shell to bash
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      shell: bash
+    username_credential: "{{ username_credential }}"
+    shell: bash
   ignore_errors: true
   register: result
 
 - name: Assert Update user shell to bash
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Update user shell to none
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      shell: none
+    username_credential: "{{ username_credential }}"
+    shell: none
   register: result
 
 - name: Assert Update user shell to none
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Update user shell to none - Idempotent check
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      shell: none
+    username_credential: "{{ username_credential }}"
+    shell: none
   register: result
 
 - name: Assert Update user shell to none - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove user
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      state: absent
+    username_credential: "{{ username_credential }}"
+    state: absent
   register: result
 
 - name: Assert Remove user
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove user - Idempotent check
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      state: absent
+    username_credential: "{{ username_credential }}"
+    state: absent
   register: result
 
 - name: Assert Remove user - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove testusernopass user
   bigip_user:
-      username_credential: testusernopass
-      state: absent
+    username_credential: testusernopass
+    state: absent
   register: result
 
 - name: Assert Remove testusernopass user
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove testusernopass user - Idempotent check
   bigip_user:
-      username_credential: testusernopass
-      state: absent
+    username_credential: testusernopass
+    state: absent
   register: result
 
 - name: Assert Remove testusernopass user - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Collect BIG-IP facts
   bigip_facts:
-      include: system_info
+    include: system_info
   register: result
 
 - name: Include version 13 (Daytona) checks
-  include: test-post-version-12-specific.yaml
+  import_tasks: test-post-version-12-specific.yaml
   when: system_info.product_information.product_version >= "13.0.0"
 
-- include: teardown.yaml
+- import_tasks: teardown.yaml
 
 # Github issues
-- include: issue-00113.yaml
+- import_tasks: issue-00113.yaml
   tags: issue-00113
 
-- include: issue-00276.yaml
+- import_tasks: issue-00276.yaml
   tags: issue-00276
 
-- include: issue-00310.yaml
+- import_tasks: issue-00310.yaml
   tags: issue-00310

--- a/test/integration/targets/bigip_user/tasks/setup.yaml
+++ b/test/integration/targets/bigip_user/tasks/setup.yaml
@@ -2,5 +2,5 @@
 
 - name: Create partition
   bigip_command:
-      commands:
-          - tmsh create auth partition foo
+    commands:
+      - tmsh create auth partition foo

--- a/test/integration/targets/bigip_user/tasks/teardown.yaml
+++ b/test/integration/targets/bigip_user/tasks/teardown.yaml
@@ -2,5 +2,5 @@
 
 - name: Remove partition
   bigip_command:
-      commands:
-          - tmsh delete auth partition foo
+    commands:
+      - tmsh delete auth partition foo

--- a/test/integration/targets/bigip_user/tasks/test-post-version-12-specific.yaml
+++ b/test/integration/targets/bigip_user/tasks/test-post-version-12-specific.yaml
@@ -1,109 +1,109 @@
 ---
 - name: Create user on a different partition
   bigip_user:
-      partition_access:
-        - foo:operator
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
-      update_password: on_create
-      partition: "{{ partition }}"
+    partition_access:
+      - foo:operator
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    update_password: on_create
+    partition: "{{ partition }}"
   register: result
 
 - name: Assert Create user on a different partition
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create user on a different partition - Idempotent check
   bigip_user:
-      partition_access:
-        - foo:operator
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
-      update_password: on_create
-      partition: "{{ partition }}"
+    partition_access:
+      - foo:operator
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    update_password: on_create
+    partition: "{{ partition }}"
   register: result
 
 - name: Assert Create user on a different partition - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Assign multiple roles for the same partition
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      partition_access:
-        - Common:operator
-        - Common:manager
-      partition: "{{ partition }}"
+    username_credential: "{{ username_credential }}"
+    partition_access:
+      - Common:operator
+      - Common:manager
+    partition: "{{ partition }}"
   register: result
 
 - name: Assert Assign multiple roles for the same partition
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Modify roles for a different partitions
   bigip_user:
-      partition_access:
-        - Common:guest
-        - foo:manager
-      username_credential: "{{ username_credential }}"
-      partition: "{{ partition }}"
+    partition_access:
+      - Common:guest
+      - foo:manager
+    username_credential: "{{ username_credential }}"
+    partition: "{{ partition }}"
   register: result
 
 - name: Assert Modify roles for a different partitions
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 
 - name: Update password for user on a different partition
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
-      partition: "{{ partition }}"
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    partition: "{{ partition }}"
   register: result
 
 - name: Assert Update password for user on a different partition
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 # We should see password not updating here
 - name: Update user password for user on a different partition password_update set to on_create
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      password_credential: "{{ password_credential }}"
-      update_password: on_create
-      partition: "{{ partition }}"
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    update_password: on_create
+    partition: "{{ partition }}"
   register: result
 
 - name: Assert Update user password for user on a different partition password_update set to on_create
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove user on different partition
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      state: absent
-      partition: "{{ partition }}"
+    username_credential: "{{ username_credential }}"
+    state: absent
+    partition: "{{ partition }}"
   register: result
 
 - name: Assert Remove user on different partition
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove user on different partition - Idempotent check
   bigip_user:
-      username_credential: "{{ username_credential }}"
-      state: absent
-      partition: "{{ partition }}"
+    username_credential: "{{ username_credential }}"
+    state: absent
+    partition: "{{ partition }}"
   register: result
 
 - name: Assert Remove user on different partition - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed


### PR DESCRIPTION
- 2-space indenting
- replace 'include: *.yaml' with 'import_tasks: *.yaml'
- replace 'with_items:' with 'loop:'