### PR TITLE
Continuuing standards and formatting updates to integration tests.

### DIFF
--- a/test/integration/bigip_vlan.yaml
+++ b/test/integration/bigip_vlan.yaml
@@ -44,11 +44,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigip_vlan
+    - bigip_vlan

--- a/test/integration/bigiq_license_pool.yaml
+++ b/test/integration/bigiq_license_pool.yaml
@@ -39,11 +39,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigiq_license_pool
+    - bigiq_license_pool

--- a/test/integration/bigiq_license_pool_member.yaml
+++ b/test/integration/bigiq_license_pool_member.yaml
@@ -39,11 +39,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - bigiq_license_pool_member
+    - bigiq_license_pool_member

--- a/test/integration/f5_support_upload.yaml
+++ b/test/integration/f5_support_upload.yaml
@@ -41,11 +41,11 @@
         - ansible.module_utils.six.*
 
   environment:
-      F5_SERVER: "{{ ansible_host }}"
-      F5_USER: "{{ bigip_username }}"
-      F5_PASSWORD: "{{ bigip_password }}"
-      F5_SERVER_PORT: "{{ bigip_port }}"
-      F5_VALIDATE_CERTS: "{{ validate_certs }}"
+    F5_SERVER: "{{ ansible_host }}"
+    F5_USER: "{{ bigip_username }}"
+    F5_PASSWORD: "{{ bigip_password }}"
+    F5_SERVER_PORT: "{{ bigip_port }}"
+    F5_VALIDATE_CERTS: "{{ validate_certs }}"
 
   roles:
-      - f5_support_upload
+    - f5_support_upload

--- a/test/integration/targets/bigip_view/tasks/main.yaml
+++ b/test/integration/targets/bigip_view/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
 
-- include: test-interface-soap.yaml
+- import_tasks: test-interface-soap.yaml
   tags:
     - soap
 
-- include: test-interface-rest.yaml
+- import_tasks: test-interface-rest.yaml
   tags:
     - rest

--- a/test/integration/targets/bigip_vlan/defaults/main.yaml
+++ b/test/integration/targets/bigip_vlan/defaults/main.yaml
@@ -3,10 +3,10 @@
 vlan_name: vlan1
 vlan_description: foo vlan
 vlan_interfaces:
-    - 1.1
+  - 1.1
 vlan_tag: 4000
 vlan_description1: new description
 vlan_interfaces1:
-    - 1.2
+  - 1.2
 vlan_tag1: 1234
 vlan_tag2: 2345

--- a/test/integration/targets/bigip_vlan/tasks/main.yaml
+++ b/test/integration/targets/bigip_vlan/tasks/main.yaml
@@ -5,255 +5,255 @@
 
 - name: Create VLAN
   bigip_vlan:
-      name: "{{ vlan_name }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Create VLAN
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create VLAN - Idempotent check
   bigip_vlan:
-      name: "{{ vlan_name }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Create VLAN - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set VLAN tag, int
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      tag: "{{ vlan_tag1 }}"
+    name: "{{ vlan_name }}"
+    tag: "{{ vlan_tag1 }}"
   register: result
 
 - name: Assert Set VLAN tag, int
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set VLAN tag, int - Idempotent check
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      tag: "{{ vlan_tag1 }}"
+    name: "{{ vlan_name }}"
+    tag: "{{ vlan_tag1 }}"
   register: result
 
 - name: Assert Set VLAN tag, int - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set VLAN tag, string
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      tag: "{{ vlan_tag2 }}"
+    name: "{{ vlan_name }}"
+    tag: "{{ vlan_tag2 }}"
   register: result
 
 - name: Assert Set VLAN tag, string
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set VLAN tag, string - Idempotent check
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      tag: "{{ vlan_tag2 }}"
+    name: "{{ vlan_name }}"
+    tag: "{{ vlan_tag2 }}"
   register: result
 
 - name: Assert Set VLAN tag, string - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set VLAN description
   bigip_vlan:
-      description: "{{ vlan_description1 }}"
-      name: "{{ vlan_name }}"
+    description: "{{ vlan_description1 }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Set VLAN description
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set VLAN description - Idempotent check
   bigip_vlan:
-      description: "{{ vlan_description1 }}"
-      name: "{{ vlan_name }}"
+    description: "{{ vlan_description1 }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Set VLAN description - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set VLAN tagged interfaces
   bigip_vlan:
-      tagged_interfaces: "{{ vlan_interfaces1 }}"
-      name: "{{ vlan_name }}"
+    tagged_interfaces: "{{ vlan_interfaces1 }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Set VLAN tagged interfaces
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set VLAN tagged interfaces - Idempotent check
   bigip_vlan:
-      tagged_interfaces: "{{ vlan_interfaces1 }}"
-      name: "{{ vlan_name }}"
+    tagged_interfaces: "{{ vlan_interfaces1 }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Set VLAN tagged interfaces - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Set VLAN untagged interfaces
   bigip_vlan:
-      untagged_interfaces: "{{ vlan_interfaces1 }}"
-      name: "{{ vlan_name }}"
+    untagged_interfaces: "{{ vlan_interfaces1 }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Set VLAN untagged interfaces
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Set VLAN untagged interfaces - Idempotent check
   bigip_vlan:
-      untagged_interfaces: "{{ vlan_interfaces1 }}"
-      name: "{{ vlan_name }}"
+    untagged_interfaces: "{{ vlan_interfaces1 }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Set VLAN untagged interfaces - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove VLAN
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      state: absent
+    name: "{{ vlan_name }}"
+    state: absent
   register: result
 
 - name: Assert Remove VLAN
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Remove VLAN - Idempotent check
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      state: absent
+    name: "{{ vlan_name }}"
+    state: absent
   register: result
 
 - name: Assert Remove VLAN - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 # VE has a limitation that you can only have one interface per VLAN
 # To test with more than one interface, you need to use a hardware
 # device
 - name: Create VLAN, tagged interfaces
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      tagged_interfaces: "{{ vlan_interfaces }}"
+    name: "{{ vlan_name }}"
+    tagged_interfaces: "{{ vlan_interfaces }}"
   register: result
 
 - name: Assert Create VLAN, tagged interfaces
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create VLAN, tagged interfaces - Idempotent check
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      tagged_interfaces: "{{ vlan_interfaces }}"
+    name: "{{ vlan_name }}"
+    tagged_interfaces: "{{ vlan_interfaces }}"
   register: result
 
 - name: Assert Create VLAN, tagged interfaces - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove VLAN, tagged interfaces
   bigip_vlan:
-      tagged_interfaces: "{{ vlan_interfaces }}"
-      name: "{{ vlan_name }}"
-      state: absent
+    tagged_interfaces: "{{ vlan_interfaces }}"
+    name: "{{ vlan_name }}"
+    state: absent
   register: result
 
 - name: Assert Remove VLAN, tagged interfaces
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create VLAN, description
   bigip_vlan:
-      description: "{{ vlan_description }}"
-      name: "{{ vlan_name }}"
+    description: "{{ vlan_description }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Create VLAN, description
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create VLAN, description - Idempotent check
   bigip_vlan:
-      description: "{{ vlan_description }}"
-      name: "{{ vlan_name }}"
+    description: "{{ vlan_description }}"
+    name: "{{ vlan_name }}"
   register: result
 
 - name: Assert Create VLAN, description - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove VLAN, description
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      state: absent
+    name: "{{ vlan_name }}"
+    state: absent
   register: result
 
 - name: Assert Remove VLAN, description
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create VLAN, tag
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      tag: "{{ vlan_tag }}"
+    name: "{{ vlan_name }}"
+    tag: "{{ vlan_tag }}"
   register: result
 
 - name: Assert Create VLAN, tag
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed
 
 - name: Create VLAN, tag - Idempotent check
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      tag: "{{ vlan_tag }}"
+    name: "{{ vlan_name }}"
+    tag: "{{ vlan_tag }}"
   register: result
 
 - name: Assert Create VLAN, tag - Idempotent check
   assert:
-      that:
-          - not result|changed
+    that:
+      - not result|changed
 
 - name: Remove VLAN, tag
   bigip_vlan:
-      name: "{{ vlan_name }}"
-      state: absent
+    name: "{{ vlan_name }}"
+    state: absent
   register: result
 
 - name: Assert Remove VLAN, tag
   assert:
-      that:
-          - result|changed
+    that:
+      - result|changed

--- a/test/integration/targets/bigip_vlan/tasks/setup.yaml
+++ b/test/integration/targets/bigip_vlan/tasks/setup.yaml
@@ -2,19 +2,19 @@
 
 - name: Remove Self IPs
   bigip_selfip:
-      name: "{{ item }}"
-      state: absent
+    name: "{{ item }}"
+    state: absent
   register: result
-  with_items:
-      - net1
-      - net2
+  loop:
+    - net1
+    - net2
 
 - name: Remove VLANs
   bigip_vlan:
-      name: "{{ item }}"
-      state: absent
+    name: "{{ item }}"
+    state: absent
   register: result
-  with_items:
-      - net1
-      - net2
-      - vlan1
+  loop:
+    - net1
+    - net2
+    - vlan1

--- a/test/integration/targets/bigip_wait/tasks/main.yaml
+++ b/test/integration/targets/bigip_wait/tasks/main.yaml
@@ -9,9 +9,9 @@
 
 - name: Attempt to make a change, expected failure
   bigip_pool:
-      lb_method: round-robin
-      name: foo-pool
-      state: present
+    lb_method: round-robin
+    name: foo-pool
+    state: present
   register: result
   ignore_errors: true
 
@@ -32,9 +32,9 @@
 
 - name: Attempt to make a change, no failure
   bigip_pool:
-      lb_method: round-robin
-      name: foo-pool
-      state: present
+    lb_method: round-robin
+    name: foo-pool
+    state: present
   register: result
   ignore_errors: true
 

--- a/test/integration/targets/bigip_wait/tasks/teardown.yaml
+++ b/test/integration/targets/bigip_wait/tasks/teardown.yaml
@@ -2,6 +2,6 @@
 
 - name: Remove pool
   bigip_pool:
-      name: foo-pool
-      state: absent
+    name: foo-pool
+    state: absent
   register: result


### PR DESCRIPTION
Updates to integration tests for bigip_view, bigip_vlan, bigip_wait, bigiq_license_pool,  bigiq_license_pool_member,  and f5_support_upload modules.  The view and vlan modules were previously updated but grep and random inspection revealed needed updates that were previously missed.

- Standardize on 2-space indents
- Replace 'include: *.yaml' with 'import_tasks: *.yaml'
- Replace 'with_items:' with 'loop:'