### PR TITLE
Fixed issues in bigip_profile_client_ssl module integration tests.

### DIFF
--- a/test/integration/targets/bigip_profile_client_ssl/tasks/issue-00398.yaml
+++ b/test/integration/targets/bigip_profile_client_ssl/tasks/issue-00398.yaml
@@ -52,3 +52,14 @@
   bigip_profile_client_ssl:
     name: my_profile
     state: absent
+
+- name: Issue 00398 - Remove certificate
+  bigip_ssl_certificate:
+    name: "{{ cert }}"
+    state: absent
+
+- name: Isue 00398 - Remove key
+  bigip_ssl_key:
+    name: "{{ key }}"
+    state: absent
+ 

--- a/test/integration/targets/bigip_profile_client_ssl/tasks/main.yaml
+++ b/test/integration/targets/bigip_profile_client_ssl/tasks/main.yaml
@@ -24,7 +24,7 @@
     that:
       - not result|changed
 
-- import_tasks: test-cert-key-chain.yaml
+# - import_tasks: test-cert-key-chain.yaml
 
 - name: Remove client SSL profile
   bigip_profile_client_ssl:
@@ -47,6 +47,8 @@
   assert:
     that:
       - not result|changed
+
+- import_tasks: test-cert-key-chain.yaml
 
 - import_tasks: issue-00398.yaml
   tags: issue-00398

--- a/test/integration/targets/bigip_profile_client_ssl/tasks/main.yaml
+++ b/test/integration/targets/bigip_profile_client_ssl/tasks/main.yaml
@@ -24,8 +24,6 @@
     that:
       - not result|changed
 
-# - import_tasks: test-cert-key-chain.yaml
-
 - name: Remove client SSL profile
   bigip_profile_client_ssl:
     name: foo

--- a/test/integration/targets/bigip_profile_client_ssl/tasks/test-cert-key-chain.yaml
+++ b/test/integration/targets/bigip_profile_client_ssl/tasks/test-cert-key-chain.yaml
@@ -54,7 +54,7 @@
 
 - name: Remove profile - Idempotent check
   bigip_profile_client_ssl:
-    name: foor
+    name: foo
     state: absent
   register: result
 

--- a/test/integration/targets/bigip_profile_client_ssl/tasks/test-cert-key-chain.yaml
+++ b/test/integration/targets/bigip_profile_client_ssl/tasks/test-cert-key-chain.yaml
@@ -41,7 +41,29 @@
     that:
       - not result|changed
 
-- name: Remove key
+- name: Remove profile
+  bigip_profile_client_ssl:
+    name: foo
+    state: absent
+  register: result
+
+- name: Assert remove profile
+  assert:
+    that:
+      - result|changed
+
+- name: Remove profile - Idempotent check
+  bigip_profile_client_ssl:
+    name: foor
+    state: absent
+  register: result
+
+- name: Assert Remove profile - Idempotent check
+  assert:
+    that:
+      - not result|changed
+
+- name: Remove cert 
   bigip_ssl_certificate:
     name: bigip_ssl_cert1
     state: absent


### PR DESCRIPTION
1. Issue-00398 test created cert/key but did not remove at end of test.
2. main.yaml imported test-cert-key-chain.yaml in the middle of another test.  moved to after current test
3. test-cert-key-chain did not remove profile at end of test.  Removed profile with idempotent checks and assertions.
