### PR TITLE
The /Common/ssh profile did not exist in 12.0.

### DIFF
--- a/test/integration/targets/bigip_virtual_server/defaults/main.yaml
+++ b/test/integration/targets/bigip_virtual_server/defaults/main.yaml
@@ -17,3 +17,7 @@ vs_profiles2:
   - qoe
   - ssh
   - tcp
+vs_profiles3:
+  - http
+  - qoe
+  - tcp

--- a/test/integration/targets/bigip_virtual_server/tasks/main.yaml
+++ b/test/integration/targets/bigip_virtual_server/tasks/main.yaml
@@ -1,5 +1,7 @@
 ---
 
+- import_tasks: setup.yaml
+
 - name: Add virtual server
   bigip_virtual_server:
     all_profiles: "{{ vs_profiles1 }}"
@@ -218,16 +220,31 @@
     that:
       - not result|changed
 
+- name: Set some profiles on virtual server pre-12.1
+  bigip_virtual_server:
+    profiles: "{{ vs_profiles3 }}"
+    name: "{{ vs_name }}"
+  register: result
+  when: system_info.product_information.product_version < "12.1.0"
+
+- name: Assert Set some profiles on virtual server pre-12.1
+  assert:
+    that:
+      - result|changed
+  when: system_info.product_information.product_version < "12.1.0"
+
 - name: Set some profiles on virtual server
   bigip_virtual_server:
     profiles: "{{ vs_profiles2 }}"
     name: "{{ vs_name }}"
   register: result
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Assert Set some profiles on virtual server
   assert:
     that:
       - result|changed
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Set less profiles on virtual server
   bigip_virtual_server:
@@ -250,17 +267,6 @@
   assert:
     that:
       - not result|changed
-
-
-
-
-
-
-
-
-
-
-
 
 - name: Delete VLAN virtual server
   bigip_virtual_server:

--- a/test/integration/targets/bigip_virtual_server/tasks/setup.yaml
+++ b/test/integration/targets/bigip_virtual_server/tasks/setup.yaml
@@ -1,0 +1,6 @@
+---
+
+- name: Collect BIG-IP facts
+  bigip_facts:
+    include: system_info
+  register: result


### PR DESCRIPTION
The bigip_virtual_server integration test that sets a collection of profiles on a virtual was failing on 12.0 because the ssh profile did not exist.  Verified in dev central that it probably did not exist until 12.1.  Created a separate collection of profiles just for 12.0.