### PR TITLE
Add change state to disabled test for bigip_virtual_server.

### DIFF
--- a/test/integration/targets/bigip_virtual_server/tasks/main.yaml
+++ b/test/integration/targets/bigip_virtual_server/tasks/main.yaml
@@ -34,6 +34,50 @@
     that:
       - not result|changed
 
+- name: Disable virtual server
+  bigip_virtual_server:
+    name: "{{ vs_name }}"
+    state: disabled
+  register: result
+
+- name: Assert Disable virtual server
+  assert:
+    that:
+      - result|changed
+
+- name: Disable virtual server - Idempotent check
+  bigip_virtual_server:
+    name: "{{ vs_name }}"
+    state: disabled
+  register: result
+
+- name: Assert Disable virtual server - Idempotent check
+  assert:
+    that:
+      - not result|changed
+
+- name: Enable virtual server
+  bigip_virtual_server:
+    name: "{{ vs_name }}"
+    state: enabled
+  register: result
+
+- name: Assert Enable virtual server
+  assert:
+    that:
+      - result|changed
+
+- name: Enable virtual server - Idempotent check
+  bigip_virtual_server:
+    name: "{{ vs_name }}"
+    state: enabled
+  register: result
+
+- name: Assert Enable virtual server - Idempotent check
+  assert:
+    that:
+      - not result|changed
+
 - name: Modify port of the Virtual Server
   bigip_virtual_server:
     name: "{{ vs_name }}"


### PR DESCRIPTION
I went through the bigip_virtual_server module integration tests to discover there aren't any tasks that will disable a virtual server so I added one and discovered that it doesn't work.  Will open a matching issue.