### PR TITLE
The auto phone home parameter did not exist in BIGIP 12.0.

### DIFF
--- a/test/integration/targets/bigip_software_update/tasks/main.yaml
+++ b/test/integration/targets/bigip_software_update/tasks/main.yaml
@@ -48,43 +48,51 @@
   bigip_software_update:
     auto_phone_home: no
   register: result
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Assert Set auto phone home to disabled
   assert:
     that:
       - result is changed
       - not result['auto_phone_home']|bool
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Set auto phone home to disabled - Idempotent check
   bigip_software_update:
     auto_phone_home: no
   register: result
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Assert Set auto phone home to disabled - Idempotent check
   assert:
     that:
       - result is not changed
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Set auto phone home to enabled
   bigip_software_update:
     auto_phone_home: yes
   register: result
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Assert Set auto phone home to enabled
   assert:
     that:
       - result is changed
       - result['auto_phone_home']|bool
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Set auto phone home to enabled - Idempotent check
   bigip_software_update:
     auto_phone_home: yes
   register: result
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Assert Set auto phone home to enabled - Idempotent check
   assert:
     that:
       - result is not changed
+  when: system_info.product_information.product_version >= "12.1.0"
 
 - name: Set frequency to daily
   bigip_software_update:

--- a/test/integration/targets/bigip_software_update/tasks/setup.yaml
+++ b/test/integration/targets/bigip_software_update/tasks/setup.yaml
@@ -1,0 +1,7 @@
+---
+
+- name: Collect BIG-IP facts
+  bigip_facts:
+    include: system_info
+  register: result
+


### PR DESCRIPTION
Tweaking integration test to skip some steps on 12.0.