### PR TITLE
edited readme and ssh-functionality to try to standardize

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,52 +24,46 @@ Ansible F5
 Introduction
 ------------
 
-This repository provides the foundation for working with F5 devices and Ansible.
+This repository provides the foundation for working with the F5 Modules for Ansible.
 The architecture of the modules makes inherent use of the BIG-IP SOAP and REST
 APIs as well as the tmsh API where required.
 
-This repository is an **incubator** for Ansible modules that we would like to
-have upstreamed over the course of time. The modules in this repository **may be
+This repository is an **incubator** for Ansible modules. The modules in this repository **may be
 broken due to experimentation or refactoring**.
 
 If you want to download the stable modules, they are shipped with Ansible
-automatically. In-between major releases of Ansible, new `stable modules can
-be found here`_.
+automatically. In-between major releases of Ansible, new |ansible_stablemodules|.
 
-These modules are freely provided to the open source community for automating
-BIG-IP device configurations using Ansible. Support for the modules is provided
-on a best effort basis by the F5 community. Please file any bugs, questions or
-enhancement requests using `Github Issues`_
+The F5 Modules for Ansible are freely provided to the open source community for automating
+BIG-IP device configurations. Support for the modules is provided on a best effort basis by the F5 community.
 
-One last ask. I'm curious who has Ansible in house and is considering using it
-with BIG-IP. If you've got the time, consider sending me an email from your
-organization introducing yourself and what you do. I love getting email.
+Please file any bugs, questions, or enhancement requests by using |ansible_issues|. For details, see |ansiblegethelp|.
 
--tim (t.rupp@f5.com)
+One last ask. We are curious about who has Ansible in-house and is considering using it with BIG-IP. If you've got the time, consider sending an email that introduces yourself and what you do. We love hearing from you.
+
+- Tim Rupp and the F5 team - solutionsfeedback@f5.com
 
 Documentation
 -------------
 
-All documentation is available on `clouddocs.f5.com`_.
+All documentation is available on |ansiblehelp|.
 
-When `writing new modules`_, please refer to the `Guidelines`_ document.
+When |writingmodules|, please refer to the |ansibleguidelines| document.
 
 Your ideas
 ----------
 
-We are curious to know what sort of modules you want to see created. If you have
-a use case and can sufficiently describe the behavior you want to see, open
-an issue here and we will hammer out the details.
+What types of modules do you want created? If you have a use case and can sufficiently describe the behavior you want to see, open an issue and we will hammer out the details.
 
 Copyright
 ---------
 
-Copyright 2017 F5 Networks Inc.
+Copyright 2017-2018 F5 Networks Inc.
 
 Support
 -------
 
-See `Support <SUPPORT.rst>`_.
+See |ansiblegethelp|.
 
 License
 -------
@@ -79,15 +73,11 @@ GPL V3
 
 This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work.
 
-See `License`_
+See `License`_.
 
 Contributor License Agreement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Individuals or business entities who contribute to this project must
-have completed and submitted the `F5 Contributor License
-Agreement <http://clouddocs.f5.com/products/orchestration/ansible/devel/development/cla-landing.html>`_
-to Ansible_CLA@f5.com prior to their code submission being included
-in this project.
+Individuals or business entities who contribute to this project must complete and submit the `F5 Contributor License Agreement <http://clouddocs.f5.com/products/orchestration/ansible/devel/development/cla-landing.html>`_ to Ansible_CLA@f5.com prior to their code submission being included in this project.
 
 
 .. |travis badge| image:: https://travis-ci.org/F5Networks/f5-ansible.svg?branch=devel
@@ -98,9 +88,32 @@ in this project.
     :target: https://f5cloudsolutions.herokuapp.com
     :alt: Slack Status
 
-.. _Guidelines: http://clouddocs.f5.com/products/orchestration/ansible/devel/development/guidelines.html
-.. _writing new modules: http://clouddocs.f5.com/products/orchestration/ansible/devel/development/writing-a-module.html
-.. _clouddocs.f5.com: http://clouddocs.f5.com/products/orchestration/ansible/devel
-.. _Github Issues: https://github.com/F5Networks/f5-ansible/issues
+
 .. _License: https://github.com/F5Networks/f5-ansible/blob/devel/COPYING
-.. _stable modules can be found here: https://github.com/ansible/ansible/tree/devel/lib/ansible/modules/network/f5
+
+
+.. |ansible_stablemodules| raw:: html
+
+   <a href="https://github.com/ansible/ansible/tree/devel/lib/ansible/modules/network/f5" target="_blank">stable modules can be found here</a>
+
+.. |ansible_issues| raw:: html
+
+   <a href="https://github.com/F5Networks/f5-ansible/issues" target="_blank">Github Issues</a>
+
+.. |ansiblehelp| raw:: html
+
+   <a href="http://clouddocs.f5.com/products/orchestration/ansible/devel/" target="_blank">clouddocs.f5.com</a>
+
+.. |writingmodules| raw:: html
+
+   <a href="http://clouddocs.f5.com/products/orchestration/ansible/devel/development/writing-a-module.html" target="_blank">writing new modules</a>
+
+.. |ansibleguidelines| raw:: html
+
+   <a href="http://clouddocs.f5.com/products/orchestration/ansible/devel/development/guidelines.html" target="_blank">Guidelines</a>
+
+.. |ansiblegethelp| raw:: html
+
+   <a href="http://clouddocs.f5.com/products/orchestration/ansible/devel/usage/support.html" target="_blank">Get Help</a>
+
+

--- a/docs/development/ssh-functionality-for-modules.rst
+++ b/docs/development/ssh-functionality-for-modules.rst
@@ -1,82 +1,56 @@
-SSH functionality for modules
-=============================
+Use SSH to configure the modules
+================================
 
-A requested feature of the F5 modules has been the ability to use SSH to configure them.
+Users have requested the ability to use SSH to configure the F5 Modules for Ansible.
 
-I looked into this possibility and after discussing with Michael about it, it was
-suggested that to retain the ability to parse structured output (ie, the REST output)
-that we should try to use local `curl` commands to the same APIs and that we would
-therefore get the same results which we could sent to our existing `Parameter` classes.
+To get the same results as the existing ``Parameter`` classes, you can try to use local ``curl`` commands to parse the REST output.
 
-This sounded goo, but it has some deficiencies that a user needs to be aware of before
-they can make use of it.
+Before you use this method, note the following limitations.
 
 Limited role usage
 ------------------
 
-By far the largest limitation is that there are only two roles who are actually able
-to use the "Advanced shell" also known as "bash".
+Only two roles can use the "Advanced shell," also known as "bash."
 
-* Administrator
-* Resource Administrator
+- Administrator
+- Resource Administrator
 
-All other roles are limited to the `tmsh` shell only. This results in two problems.
+If you have either role, you can use ``curl`` through the ``tmsh run util bash`` command.
 
-First, since you are in tmsh, you do not natively have a `curl` command that you can
-use. Normally you would be able to use `curl` because it is installed and is a standard
-feature of the system. However, you do not have a `curl` command that can be run
-from, for example `tmsh run util...`
-
-This first problem can actually be worked around if you have one of the two roles
-mention above, associated with your account.
-
-If you have either role, you can make use of curl through the `tmsh run util bash`
-command.
+All other roles are limited to the ``tmsh`` shell only. In ``tmsh``, you do not natively have a ``curl`` command you can use.
 
 Appliance mode
 --------------
 
-This restriction is where things get really hairy.
+Appliance mode's restrictions are outlined in this support article:
 
-Appliance mode's restrictions are outlined in this support article.
+- https://support.f5.com/csp/article/K12815
 
-* https://support.f5.com/csp/article/K12815
+Some of the restrictions are:
 
-I will reiterate some of those restrictions below.
+- Access to the Advanced shell (``bash``) has been removed.
+- Administrative access is limited to the Configuration utility, bigpipe shell (``bpsh``), and Traffic Management Shell (``tmsh``).
+- The root user cannot log in to the device by any means, including the serial console.
+- To disable Appliance mode, you must contact F5 to help remove Appliance mode from your license file and then perform a clean installation of the software.
 
-* Access to the Advanced shell (bash) has been removed.
-* Administrative access is limited to the Configuration utility, bigpipe shell (bpsh),
-  and Traffic Management Shell (tmsh)
-* The root user cannot log in to the device by any means, including the serial console.
-* To disable Appliance mode, you must contact F5 for assistance in removing Appliance
-  mode from your license file and then perform a clean installation of the software.
+These restrictions make it difficult to configure the device by using an API that provides structured data.
 
-The above restrictions essentially make it exceedingly difficult to configure the
-device using an API that provides structured data. Additionally, it may make some
-actions that we take in the modules completely impossible such as uploading file
-data which would appear to require SCP functionality in the case of Appliance Mode.
+In addition, some of the actions the modules take become impossible. For example, in Appliance Mode, you cannot upload file data that would require SCP functionality.
 
-As it stands, the above requirements would mean that we would need to rely on tmsh
-itself to accomplish anything. This means working with a tool that does not provide
-structured output; only free form output.
+As it stands, these requirements mean that you would need to rely on ``tmsh`` itself to accomplish your tasks.
 
-Indeed there is a `--oneline` argument that may be supplied to `tmsh` commands, but
-it is not clear to the author how parseable, or reliable, this format is.
+This means working with a tool that provides free-form output, rather than structured output.
+
+There is a ``--oneline`` argument that may be supplied to ``tmsh`` commands, but it is not clear how parseable, or reliable, this format is.
 
 Conclusion
 ----------
 
-For the above reasons, if CLI functionality is pursued for any of these modules, it
-is my recommendation that the functionality only be allowed for users who are of
-one of the following roles,
+For the above reasons, if you pursue CLI functionality for any of these modules, F5 recommends that the functionality be allowed for users with one of the following roles only:
 
-* Administrator
-* Resource Administrator
+- Administrator
+- Resource Administrator
 
-Note that it is not required that the user of the modules need worry about which
-partitions they are allowed to access. With these roles you can access **all** of
-them.
+These roles can access **all** modules.
 
-Without making this a requirement, it may not be possible to provide a user of the
-modules with a reliable way to configure the system due to restrictions that are
-put in place by other roles.
+Without making this a requirement, it may not be possible to provide you with a reliable way to configure the system, due to restrictions put in place by other roles.


### PR DESCRIPTION
The edits to ssh-functionality-for-modules was intended to address GitHub Issue 503. Please review and make sure I haven't made anything technically inaccurate.
The edits to readme were to standardize link format and add group email address.