### PR TITLE
Update bigip_pool_module.rst

### DIFF
--- a/docs/modules/bigip_pool_module.rst
+++ b/docs/modules/bigip_pool_module.rst
@@ -201,7 +201,7 @@ Examples
         state: present
         name: my-pool
         partition: Common
-        lb_method: least-connection-member
+        lb_method: least-connections-member
         slow_ramp_time: 120
       delegate_to: localhost
 


### PR DESCRIPTION
correctign a small typo in the least-connection[s]-member example