### PR TITLE
removing SDK from asm_policy

### DIFF
--- a/library/modules/bigip_asm_policy.py
+++ b/library/modules/bigip_asm_policy.py
@@ -220,30 +220,31 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 from distutils.version import LooseVersion
 
+
 try:
-    from library.module_utils.network.f5.bigip import HAS_F5SDK
-    from library.module_utils.network.f5.bigip import F5Client
+    from library.module_utils.network.f5.bigip import F5RestClient
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import cleanup_tokens
-    from library.module_utils.network.f5.common import fqdn_name
+    from library.module_utils.network.f5.common import fq_name
     from library.module_utils.network.f5.common import f5_argument_spec
-    try:
-        from library.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from library.module_utils.network.f5.common import exit_json
+    from library.module_utils.network.f5.common import fail_json
+    from library.module_utils.network.f5.icontrol import upload_file
+    from library.module_utils.network.f5.icontrol import tmos_version
+    from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
-    from ansible.module_utils.network.f5.bigip import HAS_F5SDK
-    from ansible.module_utils.network.f5.bigip import F5Client
+    from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
     from ansible.module_utils.network.f5.common import AnsibleF5Parameters
     from ansible.module_utils.network.f5.common import cleanup_tokens
-    from ansible.module_utils.network.f5.common import fqdn_name
+    from ansible.module_utils.network.f5.common import fq_name
     from ansible.module_utils.network.f5.common import f5_argument_spec
-    try:
-        from ansible.module_utils.network.f5.common import iControlUnexpectedHTTPError
-    except ImportError:
-        HAS_F5SDK = False
+    from ansible.module_utils.network.f5.common import exit_json
+    from ansible.module_utils.network.f5.common import fail_json
+    from ansible.module_utils.network.f5.icontrol import upload_file
+    from ansible.module_utils.network.f5.icontrol import tmos_version
+    from ansible.module_utils.network.f5.icontrol import module_provisioned
 
 
 class Parameters(AnsibleF5Parameters):
@@ -267,18 +268,33 @@ class Parameters(AnsibleF5Parameters):
         if self._values['template_link'] is not None:
             return self._values['template_link']
         collection = self._templates_from_device()
-        for resource in collection:
-            if resource.name == self.template.upper():
-                return dict(link=resource.selfLink)
+        for resource in collection['items']:
+            if resource['name'] == self.template.upper():
+                return dict(link=resource['selfLink'])
         return None
 
     @property
     def full_path(self):
-        return fqdn_name(self.name)
+        return fq_name(self.name)
 
     def _templates_from_device(self):
-        collection = self.client.api.tm.asm.policy_templates_s.get_collection()
-        return collection
+        uri = "https://{0}:{1}/mgmt/tm/asm/policy-templates/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+        )
+        resp = self.client.api.get(uri)
+
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return response
 
     def to_return(self):
         result = {}
@@ -463,13 +479,10 @@ class BaseManager(object):
         result = dict()
         state = self.want.state
 
-        try:
-            if state == "present":
-                changed = self.present()
-            elif state == "absent":
-                changed = self.absent()
-        except iControlUnexpectedHTTPError as e:
-            raise F5ModuleError(str(e))
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
 
         changes = self.changes.to_return()
         result.update(**changes)
@@ -521,8 +534,17 @@ class BaseManager(object):
             return self.remove()
 
     def exists(self):
-        policies = self.client.api.tm.asm.policies_s.get_collection()
-        if any(p.name == self.want.name and p.partition == self.want.partition for p in policies):
+        uri = "https://{0}:{1}/mgmt/tm/asm/policies/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+        )
+        resp = self.client.api.get(uri)
+
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+        if any(p['name'] == self.want.name and p['partition'] == self.want.partition for p in response['items']):
             return True
         return False
 
@@ -571,32 +593,92 @@ class BaseManager(object):
 
     def activate(self):
         self.have = self.read_current_from_device()
-        task = self.apply_on_device()
-        if self.wait_for_task(task):
+        task_id = self.apply_on_device()
+        if self.wait_for_task(task_id, 'apply'):
             return True
         else:
             raise F5ModuleError('Apply policy task failed.')
 
-    def wait_for_task(self, task):
+    def wait_for_task(self, task_id, task):
+        uri = ''
+        if task == 'apply':
+            uri = "https://{0}:{1}/mgmt/tm/asm/tasks/apply-policy/{2}".format(
+                self.client.provider['server'],
+                self.client.provider['server_port'],
+                task_id
+            )
+        elif task == 'import':
+            uri = "https://{0}:{1}/mgmt/tm/asm/tasks/import-policy/{2}".format(
+                self.client.provider['server'],
+                self.client.provider['server_port'],
+                task_id
+            )
         while True:
-            task.refresh()
-            if task.status in ['COMPLETED', 'FAILURE']:
+            resp = self.client.api.get(uri)
+
+            try:
+                response = resp.json()
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+
+            if 'code' in response and response['code'] == 400:
+                if 'message' in response:
+                    raise F5ModuleError(response['message'])
+                else:
+                    raise F5ModuleError(resp.content)
+
+            if response['status'] in ['COMPLETED', 'FAILURE']:
                 break
             time.sleep(1)
-        if task.status == 'FAILURE':
+
+        if response['status'] == 'FAILURE':
             return False
-        if task.status == 'COMPLETED':
+        if response['status'] == 'COMPLETED':
             return True
+
+    def _get_policy_id(self):
+        name = self.want.name
+        partition = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/asm/policies/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+        )
+        resp = self.client.api.get(uri)
+
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        policy_id = next(
+            (p['id'] for p in response['items'] if p['name'] == name and p['partition'] == partition), None
+        )
+
+        if not policy_id:
+            raise F5ModuleError("The policy was not found")
+        return policy_id
 
     def update_on_device(self):
         params = self.changes.api_params()
-        policies = self.client.api.tm.asm.policies_s.get_collection()
-        name = self.want.name
-        partition = self.want.partition
-        resource = next((p for p in policies if p.name == name and p.partition == partition), None)
-        if resource:
-            if not params['active']:
-                resource.modify(**params)
+        policy_id = self._get_policy_id()
+        uri = "https://{0}:{1}/mgmt/tm/asm/policies/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            policy_id
+        )
+        if not params['active']:
+            resp = self.client.api.patch(uri, json=params)
+
+            try:
+                response = resp.json()
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+
+            if 'code' in response and response['code'] == 400:
+                if 'message' in response:
+                    raise F5ModuleError(response['message'])
+                else:
+                    raise F5ModuleError(resp.content)
 
     def create_blank(self):
         self.create_on_device()
@@ -624,57 +706,178 @@ class BaseManager(object):
             return False
 
     def read_current_from_device(self):
-        policies = self.client.api.tm.asm.policies_s.get_collection()
-        for policy in policies:
-            if policy.name == self.want.name and policy.partition == self.want.partition:
-                params = policy.attrs
-                params.update(dict(self_link=policy.selfLink))
-                return Parameters(params=params)
-        raise F5ModuleError("The policy was not found")
+        policy_id = self._get_policy_id()
+        uri = "https://{0}:{1}/mgmt/tm/asm/policies/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            policy_id
+        )
+        resp = self.client.api.get(uri)
+
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+        response.update((dict(self_link=response['selfLink'])))
+
+        return Parameters(params=response)
+
+    def upload_file_to_device(self, content, name):
+        url = 'https://{0}:{1}/mgmt/shared/file-transfer/uploads'.format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
+        )
+        try:
+            upload_file(self.client, url, content, name)
+        except F5ModuleError:
+            raise F5ModuleError(
+                "Failed to upload the file."
+            )
 
     def import_to_device(self):
-        self.client.api.tm.asm.file_transfer.uploads.upload_file(self.want.file)
-        time.sleep(2)
         name = os.path.split(self.want.file)[1]
-        tasks = self.client.api.tm.asm.tasks
-        result = tasks.import_policy_s.import_policy.create(
-            name=self.want.name,
-            partition=self.want.partition,
-            filename=name
+        self.upload_file_to_device(self.want.file, name)
+        time.sleep(2)
+
+        full_name = fq_name(self.want.partition, self.want.name)
+        cmd = 'tmsh load asm policy {0} file /var/config/rest/downloads/{1}'.format(full_name, name)
+
+        uri = "https://{0}:{1}/mgmt/tm/util/bash/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
-        return result
+        args = dict(
+            command='run',
+            utilCmdArgs='-c "{0}"'.format(cmd)
+        )
+        resp = self.client.api.post(uri, json=args)
+
+        try:
+            response = resp.json()
+            if 'commandResult' in response:
+                if 'Unexpected Error' in response['commandResult']:
+                    raise F5ModuleError(response['commandResult'])
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return True
+
+    def remove_temp_policy_from_device(self):
+        name = os.path.split(self.want.file)[1]
+        tpath_name = '/var/config/rest/downloads/{0}'.format(name)
+        uri = "https://{0}:{1}/mgmt/tm/util/unix-rm/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+        )
+        args = dict(
+            command='run',
+            utilCmdArgs=tpath_name
+        )
+        resp = self.client.api.post(uri, json=args)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def apply_on_device(self):
-        tasks = self.client.api.tm.asm.tasks
-        result = tasks.apply_policy_s.apply_policy.create(
-            policyReference={'link': self.have.self_link}
+        uri = "https://{0}:{1}/mgmt/tm/asm/tasks/apply-policy/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
-        return result
+        params = dict(policyReference={'link': self.have.self_link})
+        resp = self.client.api.post(uri, json=params)
+
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return response['id']
 
     def create_from_template_on_device(self):
-        tasks = self.client.api.tm.asm.tasks
-        result = tasks.import_policy_s.import_policy.create(
-            name=self.want.name,
-            partition=self.want.partition,
-            policyTemplateReference=self.want.template_link
+        full_name = fq_name(self.want.partition, self.want.name)
+        cmd = 'tmsh create asm policy {0} policy-template {1}'.format(full_name, self.want.template)
+        uri = "https://{0}:{1}/mgmt/tm/util/bash/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
-        time.sleep(2)
-        return result
+        args = dict(
+            command='run',
+            utilCmdArgs='-c "{0}"'.format(cmd)
+        )
+        resp = self.client.api.post(uri, json=args)
+
+        try:
+            response = resp.json()
+            if 'commandResult' in response:
+                if 'Unexpected Error' in response['commandResult']:
+                    raise F5ModuleError(response['commandResult'])
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
 
     def create_on_device(self):
-        result = self.client.api.tm.asm.policies_s.policy.create(
-            name=self.want.name,
-            partition=self.want.partition
+        params = self.changes.api_params()
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/asm/policies/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
         )
-        return result
+        resp = self.client.api.post(uri, json=params)
+
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+        time.sleep(2)
+        return response['selfLink']
 
     def remove_from_device(self):
-        policies = self.client.api.tm.asm.policies_s.get_collection()
-        name = self.want.name
-        partition = self.want.partition
-        resource = next((p for p in policies if p.name == name and p.partition == partition), None)
-        if resource:
-            resource.delete()
+        policy_id = self._get_policy_id()
+        uri = "https://{0}:{1}/mgmt/tm/asm/policies/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            policy_id
+        )
+        response = self.client.api.delete(uri)
+        if response.status in [200, 201]:
+            return True
+        raise F5ModuleError(response.content)
 
 
 class ModuleManager(object):
@@ -683,6 +886,10 @@ class ModuleManager(object):
         self.kwargs = kwargs
 
     def exec_module(self):
+        if not module_provisioned(self.client, 'asm'):
+            raise F5ModuleError(
+                "ASM must be provisioned to use this module."
+            )
         if self.version_is_less_than_13():
             manager = self.get_manager('v1')
         else:
@@ -696,7 +903,7 @@ class ModuleManager(object):
             return V2Manager(**self.kwargs)
 
     def version_is_less_than_13(self):
-        version = self.client.api.tmos_version
+        version = tmos_version(self.client)
         if LooseVersion(version) < LooseVersion('13.0.0'):
             return True
         else:
@@ -717,31 +924,6 @@ class V1Manager(BaseManager):
     def create_from_template(self):
         self.create_from_template_on_device()
 
-    def create_from_template_on_device(self):
-        full_name = fqdn_name(self.want.partition, self.want.name)
-        cmd = 'tmsh create asm policy {0} policy-template {1}'.format(full_name, self.want.template)
-        self.client.api.tm.util.bash.exec_cmd(
-            'run',
-            utilCmdArgs='-c "{0}"'.format(cmd)
-        )
-
-    def remove_temp_policy_from_device(self):
-        name = os.path.split(self.want.file)[1]
-        tpath_name = '/var/config/rest/downloads/{0}'.format(name)
-        self.client.api.tm.util.unix_rm.exec_cmd('run', utilCmdArgs=tpath_name)
-
-    def import_to_device(self):
-        self.client.api.shared.file_transfer.uploads.upload_file(self.want.file)
-        time.sleep(2)
-        name = os.path.split(self.want.file)[1]
-        full_name = fqdn_name(self.want.partition, self.want.name)
-        cmd = 'tmsh load asm policy {0} file /var/config/rest/downloads/{1}'.format(full_name, name)
-        self.client.api.tm.util.bash.exec_cmd(
-            'run',
-            utilCmdArgs='-c "{0}"'.format(cmd)
-        )
-        return True
-
 
 class V2Manager(BaseManager):
     def __init__(self, *args, **kwargs):
@@ -751,18 +933,13 @@ class V2Manager(BaseManager):
         self.want = V2Parameters(params=module.params, client=client)
 
     def create_from_template(self):
-        task = self.create_from_template_on_device()
-        if not task:
+        if not self.create_from_template_on_device():
             return False
-        if not self.wait_for_task(task):
-            raise F5ModuleError('Import policy task failed.')
 
     def create_from_file(self):
-        task = self.import_to_device()
-        if not task:
+        if not self.import_to_device():
             return False
-        if not self.wait_for_task(task):
-            raise F5ModuleError('Import policy task failed.')
+        self.remove_temp_policy_from_device()
 
 
 class ArgumentSpec(object):
@@ -840,18 +1017,17 @@ def main():
             ['file', 'template']
         ]
     )
-    if not HAS_F5SDK:
-        module.fail_json(msg="The python f5-sdk module is required")
+
+    client = F5RestClient(**module.params)
 
     try:
-        client = F5Client(**module.params)
         mm = ModuleManager(module=module, client=client)
         results = mm.exec_module()
         cleanup_tokens(client)
-        module.exit_json(**results)
-    except F5ModuleError as e:
+        exit_json(module, results, client)
+    except F5ModuleError as ex:
         cleanup_tokens(client)
-        module.fail_json(msg=str(e))
+        fail_json(module, ex, client)
 
 
 if __name__ == '__main__':

--- a/test/integration/targets/bigip_asm_policy/tasks/issue-00406.yaml
+++ b/test/integration/targets/bigip_asm_policy/tasks/issue-00406.yaml
@@ -5,10 +5,10 @@
     file: issue-00406.yaml
 
 - name: Issue 00406 - Collect BIG-IP facts
-  bigip_facts:
-    include: system_info
-  register: result
-
+  bigip_device_facts:
+    include: system-info
+  register: f
+  
 - name: Issue 00406 - Provision ASM
   bigip_provision:
     name: asm
@@ -313,13 +313,13 @@
     file: "{{ role_path }}/files/v2_policy_default_compact_format_enabled.xml"
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Create ASM policy, compact XML file
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Create ASM policy, compact XML file - Idempotent check
   bigip_asm_policy:
@@ -327,13 +327,13 @@
     file: "{{ role_path }}/files/v2_policy_default_compact_format_enabled.xml"
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Create ASM policy, compact XML file - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as active, compact XML file
   bigip_asm_policy:
@@ -341,13 +341,13 @@
     active: yes
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as active, compact XML file
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as active, compact XML file - Idempotent check
   bigip_asm_policy:
@@ -355,13 +355,13 @@
     active: yes
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as active, compact XML file - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as inactive, compact XML file
   bigip_asm_policy:
@@ -369,13 +369,13 @@
     active: no
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as inactive, compact XML file
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as inactive, compact XML file - Idempotent check
   bigip_asm_policy:
@@ -383,13 +383,13 @@
     active: no
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as inactive, compact XML file - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Remove ASM policy
   bigip_asm_policy:
@@ -397,13 +397,13 @@
     state: absent
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Remove ASM policy
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Remove ASM policy - Idempotent check
   bigip_asm_policy:
@@ -411,13 +411,13 @@
     state: absent
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Remove ASM policy - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Create ASM policy, non-compact XML file
   bigip_asm_policy:
@@ -425,13 +425,13 @@
     file: "{{ role_path }}/files/v2_policy_default_compact_format_disabled.xml"
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Create ASM policy, non-compact XML file
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Create ASM policy, non-compact XML file - Idempotent check
   bigip_asm_policy:
@@ -439,13 +439,13 @@
     file: "{{ role_path }}/files/v2_policy_default_compact_format_disabled.xml"
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Create ASM policy, non-compact XML file - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as active, non-compact XML file
   bigip_asm_policy:
@@ -453,13 +453,13 @@
     active: yes
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as active, non-compact XML file
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as active, non-compact XML file - Idempotent check
   bigip_asm_policy:
@@ -467,13 +467,13 @@
     active: yes
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as active, non-compact XML file - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as inactive, non-compact XML file
   bigip_asm_policy:
@@ -481,13 +481,13 @@
     active: no
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as inactive, non-compact XML file
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as inactive, non-compact XML file - Idempotent check
   bigip_asm_policy:
@@ -495,13 +495,13 @@
     active: no
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as inactive, non-compact XML file - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Remove ASM policy
   bigip_asm_policy:
@@ -509,13 +509,13 @@
     state: absent
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Remove ASM policy
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Remove ASM policy - Idempotent check
   bigip_asm_policy:
@@ -523,13 +523,13 @@
     state: absent
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Remove ASM policy - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Create ASM policy, binary
   bigip_asm_policy:
@@ -537,13 +537,13 @@
     file: "{{ role_path }}/files/v2_policy_default_binary.plc"
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Create ASM policy, compact XML file
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Create ASM policy, binary - Idempotent check
   bigip_asm_policy:
@@ -551,13 +551,13 @@
     file: "{{ role_path }}/files/v2_policy_default_binary.plc"
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Create ASM policy, binary - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as active, binary
   bigip_asm_policy:
@@ -565,13 +565,13 @@
     active: yes
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as active, binary
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as active, binary - Idempotent check
   bigip_asm_policy:
@@ -579,13 +579,13 @@
     active: yes
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as active, binary - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as inactive, binary
   bigip_asm_policy:
@@ -593,13 +593,13 @@
     active: no
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as inactive, binary
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Set ASM policy as inactive, binary - Idempotent check
   bigip_asm_policy:
@@ -607,13 +607,13 @@
     active: no
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Set ASM policy as inactive, binary - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Remove ASM policy
   bigip_asm_policy:
@@ -621,13 +621,13 @@
     state: absent
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Remove ASM policy
   assert:
     that:
       - result is changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Remove ASM policy - Idempotent check
   bigip_asm_policy:
@@ -635,13 +635,13 @@
     state: absent
     partition: "{{ issue_partition }}"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Assert Remove ASM policy - Idempotent check
   assert:
     that:
       - result is not changed
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 00406 - Import ASM policy from template
   bigip_asm_policy:

--- a/test/integration/targets/bigip_asm_policy/tasks/issue-00595.yaml
+++ b/test/integration/targets/bigip_asm_policy/tasks/issue-00595.yaml
@@ -1,49 +1,49 @@
 ---
 
-- name: Issue 00406 - Include issue variables
+- name: Issue 00595 - Include issue variables
   include_vars:
-    file: issue-00406.yaml
+    file: issue-00595.yaml
 
-- name: Issue 00406 - Collect BIG-IP facts
-  bigip_facts:
-    include: system_info
-  register: result
+- name: Issue 00595 - Collect BIG-IP facts
+  bigip_device_facts:
+    include: system-info
+  register: f
 
-- name: Issue 00406 - Provision ASM
+- name: Issue 00595 - Provision ASM
   bigip_provision:
     name: asm
   tags:
     - module-provisioning
 
-- name: Issue 00406 - Create ASM policy, compact XML file, legacy
+- name: Issue 00595 - Create ASM policy, compact XML file, legacy
   bigip_asm_policy:
     name: "{{ policy_1 }}"
     file: "{{ role_path }}/files/v1_policy_invalid.xml"
   register: result
-  when: system_info.product_information.product_version < "13.0.0"
+  when: f.system_info.product_version < "13.0.0"
   failed_when: result is success
 
-- name: Issue 00406 - Assert Create ASM policy, compact XML file, legacy
+- name: Issue 00595 - Assert Create ASM policy, compact XML file, legacy
   assert:
     that:
       - result is success
-  when: system_info.product_information.product_version < "13.0.0"
+  when: f.system_info.product_version < "13.0.0"
 
-- name: Issue 00406 - Create ASM policy, compact XML file
+- name: Issue 00595 - Create ASM policy, compact XML file
   bigip_asm_policy:
     name: "{{ policy_1 }}"
     file: "{{ role_path }}/files/v2_policy_invalid.xml"
   register: result
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version < "13.0.0"
   failed_when: result is success
 
-- name: Issue 00406 - Assert Create ASM policy, compact XML file
+- name: Issue 00595 - Assert Create ASM policy, compact XML file
   assert:
     that:
       - result is success
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version < "13.0.0"
 
-- name: Issue 00406 - Deprovision ASM
+- name: Issue 00595 - Deprovision ASM
   bigip_provision:
     name: asm
     state: absent

--- a/test/integration/targets/bigip_asm_policy/tasks/main.yaml
+++ b/test/integration/targets/bigip_asm_policy/tasks/main.yaml
@@ -7,7 +7,7 @@
 - import_tasks: v1-policy.yaml
 
 - import_tasks: v2-policy.yaml
-  when: system_info.product_information.product_version >= "13.0.0"
+  when: f.system_info.product_version >= "13.0.0"
 
 - import_tasks: common.yaml
 - import_tasks: teardown.yaml

--- a/test/integration/targets/bigip_asm_policy/tasks/setup.yaml
+++ b/test/integration/targets/bigip_asm_policy/tasks/setup.yaml
@@ -1,9 +1,9 @@
 ---
 
 - name: Collect BIG-IP facts
-  bigip_facts:
-    include: system_info
-  register: result
+  bigip_device_facts:
+    include: system-info
+  register: f
 
 - name: Provision ASM
   bigip_provision:


### PR DESCRIPTION
I had to gut it good due to a bug in import-policy task endpoint. This works on v13 and v12 now 