### PR TITLE
fix check mode in bigip_selfip on create

### DIFF
--- a/library/modules/bigip_selfip.py
+++ b/library/modules/bigip_selfip.py
@@ -696,7 +696,7 @@ class ModuleManager(object):
             elif 'default' in self.want.allow_service:
                 self.want.update(dict(allow_service=['default']))
         self._set_changed_options()
-        if self.want.check_mode:
+        if self.module.check_mode:
             return True
         self.create_on_device()
         if self.exists():


### PR DESCRIPTION
selfip is created in check mode running ansible with -C option, since the wrong property is checked.
