### PR TITLE
Adding description to SNAT pool

### DIFF
--- a/library/modules/bigip_snat_pool.py
+++ b/library/modules/bigip_snat_pool.py
@@ -27,6 +27,11 @@ options:
     type: list
     aliases:
       - member
+  description:
+    description:
+      - A general description of the SNAT pool, provided by the user for their
+        benefit. It is optional.
+    type: str
   name:
     description:
       - The name of the SNAT pool.
@@ -86,6 +91,20 @@ EXAMPLES = r'''
       user: admin
       password: secret
   delegate_to: localhost
+
+- name: Add the SNAT pool 'my-snat-pool' with a description
+  bigip_snat_pool:
+    name: my-snat-pool
+    state: present
+    members:
+      - 10.10.10.10
+      - 20.20.20.20
+    description: A SNAT pool description
+    provider:
+      server: lb.mydomain.com
+      user: admin
+      password: secret
+  delegate_to: localhost
 '''
 
 RETURN = r'''
@@ -110,6 +129,7 @@ try:
     from library.module_utils.network.f5.common import f5_argument_spec
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.ipaddress import is_valid_ip
+    from library.module_utils.network.f5.compare import cmp_str_with_none
 except ImportError:
     from ansible.module_utils.network.f5.bigip import F5RestClient
     from ansible.module_utils.network.f5.common import F5ModuleError
@@ -118,21 +138,25 @@ except ImportError:
     from ansible.module_utils.network.f5.common import f5_argument_spec
     from ansible.module_utils.network.f5.common import transform_name
     from ansible.module_utils.network.f5.ipaddress import is_valid_ip
+    from ansible.module_utils.network.f5.compare import cmp_str_with_none
 
 
 class Parameters(AnsibleF5Parameters):
     api_map = {}
 
     updatables = [
-        'members'
+        'members',
+        'description',
     ]
 
     returnables = [
-        'members'
+        'members',
+        'description',
     ]
 
     api_attributes = [
-        'members'
+        'members',
+        'description',
     ]
 
 
@@ -164,6 +188,14 @@ class ModuleParameters(Parameters):
             address = self._format_member_address(member)
             result.update([address])
         return list(result)
+
+    @property
+    def description(self):
+        if self._values['description'] is None:
+            return None
+        elif self._values['description'] in ['none', '']:
+            return ''
+        return self._values['description']
 
 
 class Changes(Parameters):
@@ -214,6 +246,11 @@ class Difference(object):
         if set(self.want.members) == set(self.have.members):
             return None
         result = list(set(self.want.members))
+        return result
+
+    @property
+    def description(self):
+        result = cmp_str_with_none(self.want.description, self.have.description)
         return result
 
 
@@ -416,6 +453,7 @@ class ArgumentSpec(object):
                 type='list',
                 aliases=['member']
             ),
+            description=dict(),
             state=dict(
                 default='present',
                 choices=['absent', 'present']

--- a/test/integration/targets/bigip_snat_pool/tasks/issue-01284.yaml
+++ b/test/integration/targets/bigip_snat_pool/tasks/issue-01284.yaml
@@ -1,0 +1,60 @@
+---
+
+- name: Issue 01284 - Include issue variables
+  include_vars:
+    file: issue-01284.yaml
+
+- name: Issue 01284 - Create SNAT pool with description
+  bigip_snat_pool:
+    name: "{{ snat_pool_name }}"
+    members: "{{ members_list }}"
+    description: "{{ snat_pool_description }}"
+  register: result
+
+- name: Issue 01284 - Assert Create SNAT pool with description
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 01284 - Create SNAT pool with description - Idempotent check
+  bigip_snat_pool:
+    name: "{{ snat_pool_name }}"
+    members: "{{ members_list }}"
+    description: "{{ snat_pool_description }}"
+  register: result
+
+- name: Issue 01284 - Assert Create SNAT pool with description - Idempotent check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 01284 - Update SNAT pool description
+  bigip_snat_pool:
+    name: "{{ snat_pool_name }}"
+    members: "{{ members_list }}"
+    description: "{{ snat_pool_new_description }}"
+  register: result
+
+- name: Issue 01284 - Assert Update SNAT pool description
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 01284 - Update SNAT pool description - Idempotent check
+  bigip_snat_pool:
+    name: "{{ snat_pool_name }}"
+    members: "{{ members_list }}"
+    description: "{{ snat_pool_new_description }}"
+  register: result
+
+- name: Issue 01284 - Assert Update SNAT pool description - Idempotent check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 01284 - Delete SNAT pool
+  bigip_snat_pool:
+    name: "{{ snat_pool_name }}"
+    state: absent
+  register: result
+

--- a/test/integration/targets/bigip_snat_pool/tasks/main.yaml
+++ b/test/integration/targets/bigip_snat_pool/tasks/main.yaml
@@ -65,3 +65,6 @@
   assert:
     that:
       - result is not changed
+
+- import_tasks: issue-01284.yaml
+  tags: issue-01284

--- a/test/integration/targets/bigip_snat_pool/vars/issue-01284.yaml
+++ b/test/integration/targets/bigip_snat_pool/vars/issue-01284.yaml
@@ -1,0 +1,8 @@
+---
+
+snat_pool_name: my-snat-pool
+members_list:
+  - 10.10.10.10
+  - 20.20.20.20
+snat_pool_description: A SNAT pool description
+snat_pool_new_description: A new SNAT pool description

--- a/test/units/modules/network/f5/test_bigip_snat_pool.py
+++ b/test/units/modules/network/f5/test_bigip_snat_pool.py
@@ -70,11 +70,13 @@ class TestParameters(unittest.TestCase):
             name='my-snat-pool',
             state='present',
             members=['10.10.10.10', '20.20.20.20'],
+            description='A SNAT pool description',
             partition='Common'
         )
         p = ModuleParameters(params=args)
         assert p.name == 'my-snat-pool'
         assert p.state == 'present'
+        assert p.description == 'A SNAT pool description'
         assert len(p.members) == 2
         assert '/Common/10.10.10.10' in p.members
         assert '/Common/20.20.20.20' in p.members


### PR DESCRIPTION
Testing ran - 

```
root@ubuntu-ansible-python3:~/f5-ansible/test/integration# ansible-playbook -i inventory/hosts bigip_snat_pool.yaml -vvv --step
ansible-playbook 2.8.0
  config file = /root/nitin_ansible.cfg
  configured module search path = ['/root/f5-ansible/library/modules']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]
Using /root/nitin_ansible.cfg as config file

[...]

statically imported: /root/f5-ansible/test/integration/targets/bigip_snat_pool/tasks/issue-01284.yaml

PLAYBOOK: bigip_snat_pool.yaml **************************************************************************************************************************************************
2 plays in bigip_snat_pool.yaml


[...]

PLAY RECAP **********************************************************************************************************************************************************************
bigip2                     : ok=23   changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```


Tasks list - 

```
playbook: bigip_snat_pool.yaml

  play #1 (localhost): Metadata of bigip_snat_pool      TAGS: []
    tasks:

  play #2 (f5-test[0]): Test the bigip_snat_pool module TAGS: []
    tasks:
      bigip_snat_pool : Create SNAT pool from list of members   TAGS: []
      bigip_snat_pool : Assert Create SNAT pool from list of members    TAGS: []
      bigip_snat_pool : Create SNAT pool from list of members - Idempotent check        TAGS: []
      bigip_snat_pool : Assert Create SNAT pool from list of members - Idempotent check TAGS: []
      bigip_snat_pool : Set SNAT pool to single member  TAGS: []
      bigip_snat_pool : Assert Set SNAT pool to single member   TAGS: []
      bigip_snat_pool : Set SNAT pool to single member - Idempotent check       TAGS: []
      bigip_snat_pool : Assert Set SNAT pool to single member - Idempotent check        TAGS: []
      bigip_snat_pool : Delete a SNAT pool      TAGS: []
      bigip_snat_pool : Assert Delete a SNAT pool       TAGS: []
      bigip_snat_pool : Delete a SNAT pool - Idempotent check   TAGS: []
      bigip_snat_pool : Assert Delete a SNAT pool - Idempotent check    TAGS: []
      bigip_snat_pool : Issue 01284 - Include issue variables   TAGS: [issue-01284]
      bigip_snat_pool : Issue 01284 - Create SNAT pool with description TAGS: [issue-01284]
      bigip_snat_pool : Issue 01284 - Assert Create SNAT pool with description  TAGS: [issue-01284]
      bigip_snat_pool : Issue 01284 - Create SNAT pool with description - Idempotent check      TAGS: [issue-01284]
      bigip_snat_pool : Issue 01284 - Assert Create SNAT pool with description - Idempotent check       TAGS: [issue-01284]
      bigip_snat_pool : Issue 01284 - Update SNAT pool description      TAGS: [issue-01284]
      bigip_snat_pool : Issue 01284 - Assert Update SNAT pool description       TAGS: [issue-01284]
      bigip_snat_pool : Issue 01284 - Update SNAT pool description - Idempotent check   TAGS: [issue-01284]
      bigip_snat_pool : Issue 01284 - Assert Update SNAT pool description - Idempotent check    TAGS: [issue-01284]
      bigip_snat_pool : Issue 01284 - Delete SNAT pool  TAGS: [issue-01284]
```