### PR TITLE
Match all white space after prompt

### DIFF
--- a/library/plugins/terminal/bigip.py
+++ b/library/plugins/terminal/bigip.py
@@ -28,9 +28,9 @@ from ansible.errors import AnsibleConnectionFailure
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?(?:\([^\)]+\)){,5}(?:>|#) ?$"),
-        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
-        re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$"),
+        re.compile(br"[\r\n]?(?:\([^\)]+\)){,5}(?:>|#)\s*$"),
+        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#)\s*$"),
+        re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$]\s*$"),
         re.compile(br"(?:new|confirm) password:")
     ]
 


### PR DESCRIPTION
I encountered a timeout issue with Ansible `bigip_command` where it would get stuck because it would not detect the prompt. Oddly enough devices that were problematic were all `(cfg-sync Changes Pending)(Active)` state and they would send 2 additional characters, space and a carriage return.

Problematic device `(cfg-sync Changes Pending)(Active)(/Common)(tmos)#  ^M`
Hex for the last few chars: `29:23:20:20:0d`

Working device `(cfg-sync Changes Pending)(Standby)(/Common)(tmos)# `
Hex for the last few chars: `29:23:20`

From http://www.asciitable.com/
![image](https://user-images.githubusercontent.com/202178/60665989-d9848a80-9e5d-11e9-8362-7e4b553ac98a.png)
