### PR TITLE
issue 1344

### DIFF
--- a/library/module_utils/network/f5/icontrol.py
+++ b/library/module_utils/network/f5/icontrol.py
@@ -10,9 +10,9 @@ __metaclass__ = type
 import os
 
 try:
-    from StringIO import StringIO
-except ImportError:
     from io import StringIO
+except ImportError:
+    from StringIO import StringIO
 
 try:
     from BytesIO import BytesIO


### PR DESCRIPTION
fixes #1344
[StringIO.StringIO()](https://docs.python.org/2/library/stringio.html)(py2x) vs [io.StringIO()](https://docs.python.org/3/library/io.html)(py3x)

Bigip_data_group is using io module for StringIO buffer and icontrol.py was using module StringIO for StringIO buffer if present. If not present use io module which was the issue when using 2.7 since module StringIO is present in python pre 2.7.

Modified iControl to try io module first as it was introduced in 2.6 and try StringIO module on exception.