### PR TITLE
Fixes #1364

### DIFF
--- a/library/modules/bigip_device_info.py
+++ b/library/modules/bigip_device_info.py
@@ -90,6 +90,7 @@ options:
       - traffic-groups
       - trunks
       - udp-profiles
+      - users
       - vcmp-guests
       - virtual-addresses
       - virtual-servers
@@ -153,6 +154,7 @@ options:
       - "!traffic-groups"
       - "!trunks"
       - "!udp-profiles"
+      - "!users"
       - "!vcmp-guests"
       - "!virtual-addresses"
       - "!virtual-servers"
@@ -6088,6 +6090,53 @@ udp_profiles:
       type: bool
       sample: yes
   sample: hash/dictionary of values
+users:
+  description: Details of the users on the system
+  returned: When C(users) is specified in C(gather_subset).
+  type: complex
+  contains:
+    description:
+      description:
+        - Description of the resource.
+      returned: queried
+      type: str
+      sample: Admin user
+    full_path:
+      description:
+        - Full name of the resource as known to BIG-IP.
+      returned: queried
+      type: str
+      sample: admin
+    name:
+      description:
+        - Relative name of the resource in BIG-IP.
+      returned: queried
+      type: str
+      sample: admin
+    partition_access:
+      description:
+        - Partition that user has access to, including user role.
+      returned: queried
+      type: complex
+      contains:
+        name:
+          description:
+            - Name of patition
+          returned: queried
+          type: str
+          sample: all-partitions
+        role:
+          description:
+            - Role allowed to user on parition
+          returned: queried
+          type: str
+          sample: auditor
+    shell:
+      description:
+        - The shell assigned to the user account
+      returned: queried
+      type: str
+      sample: tmsh
 vcmp_guests:
   description: vCMP related information.
   returned: When C(vcmp-guests) is specified in C(gather_subset).
@@ -14535,6 +14584,88 @@ class TrunksFactManager(BaseManager):
             return {}
 
 
+class UsersParameters(BaseParameters):
+    api_map = {
+        'fullPath': 'full_path',
+        'partitionAccess': 'partition_access',
+    }
+
+    returnables = [
+        'full_path',
+        'name',
+        'description',
+        'partition_access',
+        'shell',
+    ]
+
+    @property
+    def partition_access(self):
+        result = []
+        if self._values['partition_access'] is None:
+            return []
+        for partition in self._values['partition_access']:
+            del partition['nameReference']
+            result.append(partition)
+        return result
+
+    @property
+    def shell(self):
+        if self._values['shell'] in [None, 'none']:
+            return None
+        return self._values['shell']
+
+
+class UsersFactManager(BaseManager):
+    def __init__(self, *args, **kwargs):
+        self.client = kwargs.get('client', None)
+        self.module = kwargs.get('module', None)
+        super(UsersFactManager, self).__init__(**kwargs)
+        self.want = UsersParameters(params=self.module.params)
+
+    def exec_module(self):
+        facts = self._exec_module()
+        result = dict(users=facts)
+        return result
+
+    def _exec_module(self):
+        results = []
+        facts = self.read_facts()
+        for item in facts:
+            attrs = item.to_return()
+            results.append(attrs)
+        results = sorted(results, key=lambda k: k['full_path'])
+        return results
+
+    def read_facts(self):
+        results = []
+        collection = self.read_collection_from_device()
+        for resource in collection:
+            attrs = resource
+            params = UsersParameters(params=attrs)
+            results.append(params)
+        return results
+
+    def read_collection_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/auth/user".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        if 'items' not in response:
+            return []
+        result = response['items']
+        return result
+
+
 class UdpProfilesParameters(BaseParameters):
     api_map = {
         'fullPath': 'full_path',
@@ -15832,6 +15963,7 @@ class ModuleManager(object):
             'traffic-groups': TrafficGroupsFactManager,
             'trunks': TrunksFactManager,
             'udp-profiles': UdpProfilesFactManager,
+            'users': UsersFactManager,
             'vcmp-guests': VcmpGuestsFactManager,
             'virtual-addresses': VirtualAddressesFactManager,
             'virtual-servers': VirtualServersFactManager,
@@ -16031,6 +16163,7 @@ class ArgumentSpec(object):
                     'traffic-groups',
                     'trunks',
                     'udp-profiles',
+                    'users',
                     'vcmp-guests',
                     'virtual-addresses',
                     'virtual-servers',
@@ -16098,6 +16231,7 @@ class ArgumentSpec(object):
                     '!traffic-groups',
                     '!trunks',
                     '!udp-profiles',
+                    '!users',
                     '!vcmp-guests',
                     '!virtual-addresses',
                     '!virtual-servers',

--- a/test/integration/targets/bigip_device_info/defaults/main.yaml
+++ b/test/integration/targets/bigip_device_info/defaults/main.yaml
@@ -10,6 +10,12 @@ pool_name: pool1
 # Used for vCMP tests
 initial_image: "{{ role_path }}/files/BIGIP-13.1.0.8-0.0.3.iso"
 
+# Used for User info testing
+username_credential: johnd
+password_credential: C0m-T19fx$s4v02mc10
+shell: bash
+
+
 valid_includes:
   - provision-info
 #  - "address_class"

--- a/test/integration/targets/bigip_device_info/tasks/issue-01364.yaml
+++ b/test/integration/targets/bigip_device_info/tasks/issue-01364.yaml
@@ -1,0 +1,34 @@
+---
+
+- name: Issue 01364 - Select users facts
+  bigip_device_info:
+    include:
+      - users
+  register: result
+
+- name: Issue 01364 - Assert users facts
+  assert:
+    that:
+      - result is success
+
+- name: Issue 01364 - Create an admin user
+  bigip_user:
+    partition_access:
+      - all:admin
+    username_credential: "{{ username_credential }}"
+    password_credential: "{{ password_credential }}"
+    update_password: on_create
+    shell: "{{ shell }}"
+  register: result
+
+- name: Issue 01364 - Select users facts
+  bigip_device_info:
+    include:
+      - users
+  register: result
+
+- name: Issue 01364 - Assert users facts changed
+  assert:
+    that:
+      - result is success
+      - result.users | selectattr("name", "match", "johnd") | map(attribute='shell') | first == 'bash'

--- a/test/integration/targets/bigip_device_info/tasks/main.yaml
+++ b/test/integration/targets/bigip_device_info/tasks/main.yaml
@@ -475,3 +475,6 @@
 
 - import_tasks: issue-01391.yaml
   tags: issue-01391
+
+- import_tasks: issue-01364.yaml
+  tags: issue-01364


### PR DESCRIPTION
I've left out the encrypted password as it doesn't make sense to include that information in the response. Primary use of bigip_device_info -> users  is to allow customers to track the users that exist.