### PR TITLE
updating transform_name to allow for route domain; fixes #1401

### DIFF
--- a/library/module_utils/network/f5/common.py
+++ b/library/module_utils/network/f5/common.py
@@ -251,6 +251,7 @@ def transform_name(partition='', name='', sub_path=''):
 
     if name:
         name = name.replace('/', '~')
+        name = name.replace('%', '%25')
 
     if partition:
         partition = partition.replace('/', '~')

--- a/test/units/module_utils/network/f5/test_common.py
+++ b/test/units/module_utils/network/f5/test_common.py
@@ -95,3 +95,10 @@ class TestModuleUtils(unittest.TestCase):
         # sub-path. This sub-path exists **between** the partition and
         # the resource name.
         assert transform_name('Common', '/Common/foo', 'bar.app') == '~Common~bar.app~foo'
+
+    def test_transform_name_9(self):
+        # Test a resource that has a route domain in its name
+        #
+        # The percent sign needs to be escaped for the correct API access
+        # The URL escape for '%' is '%25'
+        assert transform_name('Common', 'foo%3456') == '~Common~foo%253456'


### PR DESCRIPTION
Updating transform_name util to escape route domain in pool names, nodes, etc.

Does NOT escape the same for partition name.

Proof of unit test passing - 

```
root@ubuntu-ansible-python2-7:~/f5-ansible# python -m pytest test/units/module_utils/network/f5/
============================================================================================ test session starts ============================================================================================
platform linux2 -- Python 2.7.5, pytest-4.6.4, py-1.8.0, pluggy-0.12.0
rootdir: /root/f5-ansible
collected 9 items

test/units/module_utils/network/f5/test_common.py .........                                                                                                                                           [100%]

========================================================================================= 9 passed in 0.05 seconds ==========================================================================================
root@ubuntu-ansible-python2-7:~/f5-ansible#
```