### PR TITLE
fix issue 1344

### DIFF
--- a/library/module_utils/network/f5/icontrol.py
+++ b/library/module_utils/network/f5/icontrol.py
@@ -10,9 +10,9 @@ __metaclass__ = type
 import os
 
 try:
-    from io import StringIO
-except ImportError:
     from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 try:
     from BytesIO import BytesIO

--- a/library/modules/bigip_data_group.py
+++ b/library/modules/bigip_data_group.py
@@ -156,6 +156,7 @@ extends_documentation_fragment: f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)
+  - Greg Crosby (@crosbygw)
 '''
 
 EXAMPLES = r'''
@@ -281,7 +282,10 @@ import re
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
-from io import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 try:
     from library.module_utils.network.f5.bigip import F5RestClient


### PR DESCRIPTION
fixes #1344 
StringIO.StringIO()(py2x) vs io.StringIO()(py3x)

Modified bigip_data_group to first try to import StringIO (2.7) and if fails use io.StringIO (2.6+). This mirrors how icontrol.py is importing string buffer modules.

[test results.zip](https://github.com/F5Networks/f5-ansible/files/3427788/test.results.zip)
