### PR TITLE
Added ansible_facts return variable with ansible_net_ prefix.

### DIFF
--- a/library/modules/bigip_device_info.py
+++ b/library/modules/bigip_device_info.py
@@ -16257,7 +16257,14 @@ def main():
     try:
         mm = ModuleManager(module=module)
         results = mm.exec_module()
-        module.exit_json(**results)
+
+        ansible_facts = dict()
+
+        for key, value in iteritems(results):
+          key = 'ansible_net_%s' % key
+          ansible_facts[key] = value
+
+        module.exit_json(ansible_facts=ansible_facts, **results)
     except F5ModuleError as ex:
         module.fail_json(msg=str(ex))
 

--- a/library/modules/bigip_device_info.py
+++ b/library/modules/bigip_device_info.py
@@ -16261,8 +16261,8 @@ def main():
         ansible_facts = dict()
 
         for key, value in iteritems(results):
-          key = 'ansible_net_%s' % key
-          ansible_facts[key] = value
+            key = 'ansible_net_%s' % key
+            ansible_facts[key] = value
 
         module.exit_json(ansible_facts=ansible_facts, **results)
     except F5ModuleError as ex:


### PR DESCRIPTION
Added ansible_facts return variable on module.exit_json() to implement better support e.g. for facts caching in Ansible Tower and removing need to register variables. 

Also prepended all fact keys with ansible_net_ prefix. Old style device information is also returned for backward compatibility.