### PR TITLE
Fixes #1587

### DIFF
--- a/library/modules/bigip_data_group.py
+++ b/library/modules/bigip_data_group.py
@@ -747,6 +747,18 @@ class ApiParameters(Parameters):
         return result
 
     @property
+    def records(self):
+        cleaned_records_list = []
+        if self._values['records'] is None:
+            return None
+        for record in self._values['records']:
+            clean_record = {}
+            for k, v in record.items():
+                clean_record[k] = re.sub('\\\\', '', v)
+            cleaned_records_list.append(clean_record)
+        return cleaned_records_list
+
+    @property
     def records_list(self):
         return self._values['records']
 

--- a/test/integration/targets/bigip_data_group/tasks/issue-01587.yaml
+++ b/test/integration/targets/bigip_data_group/tasks/issue-01587.yaml
@@ -1,0 +1,44 @@
+---
+
+- name: Issue 01587 - Create a data group with a question mark
+  bigip_data_group:
+    name: foo
+    internal: yes
+    records:
+      - key: 2402:6941::/32
+        value: "This has a ? question mark"
+    type: address
+  register: result
+
+- name: Issue 01587 - Assert Create a data group with a question mark
+  assert:
+    that:
+      - result is changed
+      - result.records[0].name == "2402:6941::/32"
+
+- name: Issue 01587 - Create a data group with a question mark - Idempotent check
+  bigip_data_group:
+    name: foo
+    internal: yes
+    records:
+      - key: 2402:6941::/32
+        value: "This has a ? question mark"
+    type: address
+  register: result
+
+- name: Issue 01587 - Assert Create a data group with a question mark - Idempotent check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 01587 - Remove internal datagroup
+  bigip_data_group:
+    internal: "yes"
+    name: 'foo'
+    state: absent
+  register: result
+
+- name: Issue 01587 - Assert Remove internal datagroup
+  assert:
+    that:
+      - result is changed

--- a/test/integration/targets/bigip_data_group/tasks/main.yaml
+++ b/test/integration/targets/bigip_data_group/tasks/main.yaml
@@ -24,3 +24,6 @@
 
 - import_tasks: issue-01607.yaml
   tags: issue-01607
+
+- import_tasks: issue-01587.yaml
+  tags: issue-01587


### PR DESCRIPTION
I looked far and wide for a solution such that we could use python's decode functionality, but we're handicapped by the fact that BIG-IP adds two backslashes instead of one. This is necessary to display the config in tmsh.

So, the safest way to do this is to do a regex replace.

Currently, only dealing with the situation where the string '\\?' shows up. If in the future, we find more corner cases, we should convert this into a function, and then perhaps a library function.