### PR TITLE
FMFA-413: Update bigip_gtm_wide_ip module to allow passing pools order

### DIFF
--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/environment/issue-01597.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/environment/issue-01597.yaml
@@ -1,0 +1,157 @@
+---
+
+- name: Issue 01597 - Provision GTM on the device
+  bigip_provision:
+      module: gtm
+  tags:
+      - module-provisioning
+
+- name: Issue 01597 - Create wide pool1
+  bigip_gtm_pool:
+      name: pool1
+      type: a
+      state: present
+  register: result
+
+- name: Issue 01597 - Assert Create pool1
+  assert:
+      that:
+          - result is success
+
+- name: Issue 01597 -  Create wide pool2
+  bigip_gtm_pool:
+      name: pool2
+      type: a
+      state: present
+  register: result
+
+- name: Issue 01597 - Assert Create pool2
+  assert:
+      that:
+          - result is success
+
+- name: Issue 01597 - Create wide IP - Type A
+  bigip_gtm_wide_ip:
+      lb_method: "{{ valid_lb_method1 }}"
+      state: present
+      type: a
+      pools:
+          - name: pool1
+            ratio: 1
+            order: 1
+          - name: pool2
+            ratio: 2
+            order: 0
+      wide_ip: "{{ wide_ip1 }}"
+  register: result
+
+- name: Assert Create wide IP - Type A
+  assert:
+      that:
+          - result is changed
+
+- name: Issue 01597 - Create wide IP - Type A - Idempotent check
+  bigip_gtm_wide_ip:
+      lb_method: "{{ valid_lb_method1 }}"
+      state: present
+      type: a
+      pools:
+          - name: pool1
+            ratio: 1
+            order: 1
+          - name: pool2
+            ratio: 2
+            order: 0
+      wide_ip: "{{ wide_ip1 }}"
+  register: result
+
+- name: Assert Create wide IP - Type A - Idempotent check
+  assert:
+      that:
+          - result is not changed
+
+- name: Issue 01597 - Create wide IP - Type A - with default values - Idempotent check
+  bigip_gtm_wide_ip:
+      lb_method: "{{ valid_lb_method1 }}"
+      state: present
+      type: a
+      pools:
+          - name: pool1
+            order: 1
+          - name: pool2
+            ratio: 2
+      wide_ip: "{{ wide_ip1 }}"
+  register: result
+
+- name: Assert Modify wide IP - Type A - with default values - Idempotent check
+  assert:
+      that:
+          - result is not changed
+
+- name: Issue 01597 - Modify wide IP - Type A - order and ratio are not provided
+  bigip_gtm_wide_ip:
+      lb_method: "{{ valid_lb_method1 }}"
+      state: present
+      type: a
+      pools:
+          - name: pool1
+            ratio: 1
+            order: 0
+          - name: pool2
+      wide_ip: "{{ wide_ip1 }}"
+  register: result
+
+- name: Assert Modify wide IP - Type A - order and ratio are not provided
+  assert:
+      that:
+          - result is changed
+
+- name: Issue 01597 - Modify wide IP - Type A - order and ratio are not provided - Idempotent check
+  bigip_gtm_wide_ip:
+      lb_method: "{{ valid_lb_method1 }}"
+      state: present
+      type: a
+      pools:
+          - name: pool1
+            ratio: 1
+            order: 0
+          - name: pool2
+      wide_ip: "{{ wide_ip1 }}"
+  register: result
+
+- name: Assert Modify wide IP - Type A - order and ratio are not provided - Idempotent check
+  assert:
+      that:
+          - result is not changed
+
+- name: Issue 01597 - Delete wide IP - Type A
+  bigip_gtm_wide_ip:
+      state: absent
+      type: a
+      wide_ip: "{{ wide_ip1 }}"
+  register: result
+
+- name: Assert Delete wide IP - Type A
+  assert:
+      that:
+          - result is changed
+
+- name: Issue 01597 - Delete wide IP - Type A - Idempotent check
+  bigip_gtm_wide_ip:
+      state: absent
+      type: a
+      wide_ip: "{{ wide_ip1 }}"
+  register: result
+
+- name: Assert Delete wide IP - Type A - Idempotent check
+  assert:
+      that:
+          - result is not changed
+
+- name: Issue 01597 - Deprovision GTM
+  bigip_provision:
+      module: gtm
+      state: absent
+  tags:
+      - module-provisioning
+      - deprovision-module

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/environment/main.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/environment/main.yaml
@@ -35,5 +35,8 @@
 - import_tasks: issue-00821.yaml
   tags: issue-00821
 
+- import_tasks: issue-01597.yaml
+  tags: issue-01597
+
 - import_tasks: issue-persistence.yaml
   tags: issue-persistence

--- a/test/integration/targets/bigip_gtm_wide_ip/tasks/environment/type-a-gtm-wideip.yaml
+++ b/test/integration/targets/bigip_gtm_wide_ip/tasks/environment/type-a-gtm-wideip.yaml
@@ -15,7 +15,7 @@
   assert:
     that:
       - result is success
-      - "'is a required key for items in the list of pools.' in result.msg"
+      - "'missing required arguments: name found in pools' in result.msg"
 
 - name: Attempt to create pool without name 2 - Expected failure
   bigip_gtm_wide_ip:
@@ -31,7 +31,8 @@
   assert:
     that:
       - result is success
-      - "'is a required key for items in the list of pools.' in result.msg"
+      - "'could not parse JSON or key=value' in result.msg"
+
 
 - name: Create wide IP - Type A
   bigip_gtm_wide_ip:

--- a/test/units/modules/network/f5/fixtures/load_gtm_wide_ip_with_pools.json
+++ b/test/units/modules/network/f5/fixtures/load_gtm_wide_ip_with_pools.json
@@ -25,6 +25,24 @@
           "nameReference": {
               "link": "https://localhost/mgmt/tm/gtm/pool/a/~Common~baz?ver=13.0.0"
           }
+      },
+      {
+        "name": "maz",
+        "partition": "Common",
+        "order": 1,
+        "ratio": 10,
+        "nameReference": {
+          "link": "https://localhost/mgmt/tm/gtm/pool/a/~Common~maz?ver=13.0.0"
+        }
+      },
+      {
+        "name": "vaz",
+        "partition": "Common",
+        "order": 2,
+        "ratio": 11,
+        "nameReference": {
+          "link": "https://localhost/mgmt/tm/gtm/pool/a/~Common~vaz?ver=13.0.0"
+        }
       }
   ]
 }

--- a/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
@@ -106,11 +106,19 @@ class TestParameters(unittest.TestCase):
     def test_api_pools(self):
         args = load_fixture('load_gtm_wide_ip_with_pools.json')
         p = ApiParameters(params=args)
-        assert len(p.pools) == 1
+        assert len(p.pools) == 3
         assert 'name' in p.pools[0]
         assert 'ratio' in p.pools[0]
+        assert 'order' in p.pools[0]
         assert p.pools[0]['name'] == '/Common/baz'
         assert p.pools[0]['ratio'] == 10
+        assert p.pools[0]['order'] == 0
+        assert p.pools[1]['name'] == '/Common/maz'
+        assert p.pools[1]['ratio'] == 10
+        assert p.pools[1]['order'] == 1
+        assert p.pools[2]['name'] == '/Common/vaz'
+        assert p.pools[2]['ratio'] == 11
+        assert p.pools[2]['order'] == 2
 
     def test_module_not_fqdn_name(self):
         args = dict(
@@ -232,8 +240,18 @@ class TestTypedManager(unittest.TestCase):
             type='a',
             pools=[
                 dict(
-                    name='foo',
-                    ratio=10
+                    name='baz',
+                    ratio=10,
+                ),
+                dict(
+                    name='maz',
+                    ratio=10,
+                    order=1
+                ),
+                dict(
+                    name='vaz',
+                    ratio=11,
+                    order=2
                 )
             ],
             provider=dict(
@@ -274,7 +292,17 @@ class TestTypedManager(unittest.TestCase):
             pools=[
                 dict(
                     name='baz',
-                    ratio=10
+                    ratio=10,
+                ),
+                dict(
+                    name='maz',
+                    ratio=10,
+                    order=1
+                ),
+                dict(
+                    name='vaz',
+                    ratio=11,
+                    order=2
                 )
             ],
             provider=dict(


### PR DESCRIPTION
### Summary 

This change allows specifying order on pools used for bigip_gtm_wide_ip module. 


### Changes

-  Update bigip_gtm_wide_ip module to allow setting order value for each pool
-  Update unit tests to test new property
- Update integration tests 

### Additional details