### PR TITLE
FMFA-467: Enable support for set_variable action on bigip_pool_rule module

### DIFF
--- a/test/integration/targets/bigip_policy_rule/tasks/issue-01546.yaml
+++ b/test/integration/targets/bigip_policy_rule/tasks/issue-01546.yaml
@@ -1,8 +1,14 @@
 ---
 
+- name: Collect BIG-IP facts
+  bigip_device_info:
+      include: system-info
+  register: f
+
 - name: Issue 01546 - Create published policy
   bigip_policy:
     name: issue-01546
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 01546 - Create published rule with actions
   bigip_policy_rule:
@@ -12,12 +18,14 @@
       - type: reset
         event: ssl_client_hello
   register: result
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 01546 - Assert Create published rule with actions
   assert:
     that:
       - result is changed
       - result is success
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 01546 - Create published rule with actions - Idempotent check
   bigip_policy_rule:
@@ -27,12 +35,14 @@
       - type: reset
         event: ssl_client_hello
   register: result
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 01546 - Assert Create published rule with actions - Idempotent check
   assert:
     that:
       - result is not changed
       - result is success
+  when: f.system_info.product_version >= "13.0.0"
 
 - name: Issue 01546 - Remove policy
   bigip_policy:

--- a/test/integration/targets/bigip_policy_rule/tasks/issue-01678.yaml
+++ b/test/integration/targets/bigip_policy_rule/tasks/issue-01678.yaml
@@ -1,0 +1,77 @@
+---
+
+- name: Issue 01678 - Create published policy
+  bigip_policy:
+      name: issue-01678
+
+- name: Issue 01678 - Create published rule with set_variable actions
+  bigip_policy_rule:
+    policy: issue-01678
+    name: rule1
+    actions:
+      - type: set_variable
+        variable_name: user-agent
+        expression: tcl:[HTTP::header User-Agent]
+  register: result
+
+- name: Issue 01678 - Assert Create published rule with set_variable actions
+  assert:
+    that:
+          - result is changed
+          - result is success
+
+- name: Issue 01678 - Create published rule with set_variable actions - Idempotent check
+  bigip_policy_rule:
+    policy: issue-01678
+    name: rule1
+    actions:
+      - type: set_variable
+        variable_name: user-agent
+        expression: tcl:[HTTP::header User-Agent]
+  register: result
+
+- name: Issue 01678 - Assert Create published rule with set_variable actions - Idempotent check
+  assert:
+    that:
+      - result is not changed
+      - result is success
+
+- name: Issue 01678 - Modify published rule event with set_variable actions
+  bigip_policy_rule:
+    policy: issue-01678
+    name: rule1
+    actions:
+      - type: set_variable
+        variable_name: user-agent
+        expression: tcl:[HTTP::header User-Agent]
+        event: response
+  register: result
+
+- name: Issue 01678 - Modify published rule event with set_variable actions
+  assert:
+    that:
+      - result is changed
+      - result is success
+
+- name: Issue 01678 - Modify published rule event with set_variable actions - Idempotent check
+  bigip_policy_rule:
+    policy: issue-01678
+    name: rule1
+    actions:
+      - type: set_variable
+        variable_name: user-agent
+        expression: tcl:[HTTP::header User-Agent]
+        event: response
+  register: result
+
+- name: Issue 01678 - Modify published rule event with set_variable actions - Idempotent check
+  assert:
+    that:
+      - result is not changed
+      - result is success
+
+- name: Issue 01678 - Remove policy
+  bigip_policy:
+    name: issue-01678
+    state: absent
+  register: result

--- a/test/integration/targets/bigip_policy_rule/tasks/main.yaml
+++ b/test/integration/targets/bigip_policy_rule/tasks/main.yaml
@@ -397,4 +397,7 @@
 - import_tasks: issue-01521.yaml
   tags: issue-01521
 
+- import_tasks: issue-01678.yaml
+  tags: issue-01678
+
 - import_tasks: teardown.yaml


### PR DESCRIPTION
### Summary 

This change is intended to enable support for set_variable action for bigip_pool_rule module. 
Related to the following issue: https://github.com/F5Networks/f5-ansible/issues/1678

### Changes

 - Update bigip_module_rule module to allow setting set_variable action
 - Add integration tests for new action

### Integration tests results

```
PLAY RECAP **************************************************************************************************************************************************************************************************************************************************************
bigip_v12                  : ok=206  changed=76   unreachable=0    failed=0    skipped=8    rescued=0    ignored=2   
bigip_v13                  : ok=212  changed=79   unreachable=0    failed=0    skipped=2    rescued=0    ignored=2   
bigip_v14                  : ok=212  changed=79   unreachable=0    failed=0    skipped=2    rescued=0    ignored=2   
bigip_v15                  : ok=212  changed=79   unreachable=0    failed=0    skipped=2    rescued=0    ignored=2     
```