### PR TITLE
fix for #1723

### DIFF
--- a/library/modules/bigip_profile_client_ssl.py
+++ b/library/modules/bigip_profile_client_ssl.py
@@ -551,7 +551,7 @@ class ModuleParameters(Parameters):
             return name + '.crt'
 
     def _get_chain_value(self, item, true_name):
-        if 'chain' not in item or item['chain'] == 'none':
+        if 'chain' not in item or item['chain'] == 'none' or item['chain'] is None:
             result = 'none'
         else:
             result = self._cert_filename(fq_name(self.partition, item['chain']), true_name)


### PR DESCRIPTION
`chain` gets filled to None value by ansible if not defined.
```
    name: some_cert
    parent: clientssl
    cert_key_chain:
      - cert: some_cert.crt
        key: some_cert.key
```
Produces:
```
    {'cert': some_cert.crt', 'key': 'some_cert.key', 'true_names': False, 'chain': None, 'passphrase': None}
```