### PR TITLE
fix bigip_apm_policy_fetch issue

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_apm_policy_fetch.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_apm_policy_fetch.py
@@ -435,6 +435,7 @@ class ModuleManager(object):
             return True
         raise F5ModuleError(resp.content)
 
+
 class ArgumentSpec(object):
     def __init__(self):
         self.supports_check_mode = True


### PR DESCRIPTION
- change from asm rest endpoint to software-image-downloads endpoint
- replace `download_file` with `download_asm_file` (import from` ..module_utils.icontrol`) to adopt to new endpoint
- add `_move_file_to_download` to `create_on_device` function (similar to `bigip_asm_policy_fetch` approach)
- update paths as relevant

addresses #1780
status: works for me