### PR TITLE
Expose sync-status in bigip_device_info

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
@@ -13570,14 +13570,14 @@ class SyncStatusParameters(BaseParameters):
     @property
     def details(self):
         result = []
-        details = self._values.get('https://localhost/mgmt/tm/cm/syncStatus/0/details', {}) \
-                               .get('nestedStats', {}) \
-                               .get('entries', {})
+        details = (self._values.get('https://localhost/mgmt/tm/cm/syncStatus/0/details', {})
+                               .get('nestedStats', {})
+                               .get('entries', {}))
         for entry in details.keys():
             result.append(
-                details[entry].get('nestedStats', {}) \
-                              .get('entries', {}) \
-                              .get('details', {}) \
+                details[entry].get('nestedStats', {})
+                              .get('entries', {})
+                              .get('details', {})
                               .get('description', "")
             )
         result.reverse()


### PR DESCRIPTION
Exposes the configuration synchronization status in `bigip_device_info`.
`sync-status` is added as an option to fetch the sync status.
This addresses github issue #1778

The implementation uses the REST API endpoint `/mgmt/tm/cm/sync-status`,
this will prevent config-sync pending changes, as described in #1734

Unfortunately the REST API aggregates the sync-status across all device-groups. This means it isn't easily possible to identify the status of all device-groups individually and device-groups which are 'In Sync' might be omitted.

The following playbook
```yaml
tasks:
  - name: get sync-status
    bigip_device_info:
      provider: "{{ provider }}"
      gather_subset:
        - sync-status
    register: bigip_facts

  - name: output sync status
    vars:
      jmesquery: "sync_status"
    debug:
      msg: "{{ bigip_facts | json_query(jmesquery) }}"
```
would produce an output similar to the below:

```json
{
  "msg": [{
    "color": "red",
    "details": [
      "bigip2.example.com: connected",
      "my_syncfailover_devicegroup (Changes Pending): There is a possible change conflict between bigip1.example.com and bigip2.example.com.",
      " - Recommended action: Synchronize bigip2.example.com to group my_syncfailover_devicegroup"
    ],
    "mode": "high-availability",
    "recommended_action": "Synchronize bigip2.example.com to group my_syncfailover_devicegroup",
    "status": "Changes Pending",
    "summary": "There is a possible change conflict between bigip1.example.com and bigip2.example.com."
  }]
}
```

This allows extracting specific fields to take decisions or make recommendations based on the sync-status:
```yaml
tasks:
  - name: get sync-status
    bigip_device_info:
      provider: "{{ provider }}"
      gather_subset:
        - sync-status
    register: bigip_facts

  - name: get sync status
    vars:
      jmesquery: "sync_status[0].[color, recommended_action]"
    set_fact:
      bigip_sync_status: "{{ bigip_facts | json_query(jmesquery) }}"

  - name: check sync status is green
    fail:
      msg: "FAILED! sync status is: {{ bigip_sync_status[0] }}, please consider following the recommended action: {{ bigip_sync_status[1] }}"
    when: bigip_sync_status[0] != "green"
```
The above example would unless the sync-status is green.

Based on the status of the previous example , this would print the following error message:
```
fatal: [bigip1.example.com]: FAILED! => {"changed": false, "msg": "FAILED! sync status is: red, please consider following the recommended action: Synchronize bigip2.example.com to group my_syncfailover_devicegroup"}
```