### PR TITLE
Fixes #1728

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/action/bigip.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/action/bigip.py
@@ -66,7 +66,7 @@ class ActionModule(ActionNetworkModule):
                 pc.port = int(provider['server_port'] or self._play_context.port or 22)
                 pc.remote_user = provider['user'] or self._play_context.connection_user
                 pc.password = provider['password'] or self._play_context.password
-                pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
+                pc.private_key_file = provider.get('ssh_keyfile', None) or self._play_context.private_key_file
                 command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
                 display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
@@ -225,7 +225,7 @@ from ..module_utils.common import (
 )
 
 try:
-    from .module_utils.common import run_commands
+    from ..module_utils.common import run_commands
     HAS_CLI_TRANSPORT = True
 except ImportError:
     HAS_CLI_TRANSPORT = False
@@ -513,7 +513,11 @@ class BaseManager(object):
         else:
             failed_conditions = [item.raw for item in conditionals]
             errmsg = 'One or more conditional statements have not been satisfied.'
-            raise FailedConditionsError(errmsg, failed_conditions)
+            from ansible.module_utils.common.warnings import warn
+            # display = Display()
+            warn(errmsg)
+            warn(failed_conditions)
+            raise F5ModuleError(errmsg, failed_conditions)
         stdout_lines = self._to_lines(responses)
         changes = {
             'stdout': responses,

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
@@ -203,16 +203,12 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
 
 try:
-    from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import (
-        FailedConditionsError, Conditional
-    )
+    from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import Conditional
     from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
         ComplexList, to_list
     )
 except ImportError:
-    from ansible.module_utils.network.common.parsing import (
-        FailedConditionsError, Conditional
-    )
+    from ansible.module_utils.network.common.parsing import Conditional
     from ansible.module_utils.network.common.utils import (
         ComplexList, to_list
     )
@@ -512,11 +508,7 @@ class BaseManager(object):
             retries -= 1
         else:
             failed_conditions = [item.raw for item in conditionals]
-            errmsg = 'One or more conditional statements have not been satisfied.'
-            from ansible.module_utils.common.warnings import warn
-            # display = Display()
-            warn(errmsg)
-            warn(failed_conditions)
+            errmsg = 'The following wait_for conditional statements have not been satisfied.'
             raise F5ModuleError(errmsg, failed_conditions)
         stdout_lines = self._to_lines(responses)
         changes = {

--- a/test/integration/targets/bigip_command/tasks/provider-cli/issue-01728.yaml
+++ b/test/integration/targets/bigip_command/tasks/provider-cli/issue-01728.yaml
@@ -1,0 +1,20 @@
+---
+
+- name: Issue 01728 - run show version and see failure
+  bigip_command:
+    commands: 
+      - show sys version
+    wait_for: result[0] contains BIG-IP2
+    provider:
+      transport: cli
+      user: "{{ bigip_ssh_username }}"
+      server: "{{ ansible_host }}"
+      server_port: "{{ bigip_ssh_port }}"
+      password: "{{ bigip_ssh_password }}"
+  register: result
+  ignore_errors: true
+
+- name: Issue 01728 - Assert run show version and see failure
+  assert:
+    that:
+      - "'wait_for conditional statements have not been satisfied' not in result"

--- a/test/integration/targets/bigip_command/tasks/provider-cli/main.yaml
+++ b/test/integration/targets/bigip_command/tasks/provider-cli/main.yaml
@@ -1,9 +1,10 @@
 ---
 
-- name: Run single command - provider-cli
+- name: run show version and check to see if output contains BIG-IP
   bigip_command:
-    commands:
-      - tmsh show sys version
+    commands: 
+      - show sys version
+    wait_for: result[0] contains BIG-IP2
     provider:
       transport: cli
       user: "{{ bigip_ssh_username }}"
@@ -11,134 +12,147 @@
       server_port: "{{ bigip_ssh_port }}"
       password: "{{ bigip_ssh_password }}"
   register: result
+  delegate_to: localhost
 
-- name: Assert Run single command - provider-cli
-  assert:
-    that:
-      - result.stdout_lines|length == 1
+# - name: Run single command - provider-cli
+#   bigip_command:
+#     commands:
+#       - tmsh show sys version
+#     provider:
+#       transport: cli
+#       user: "{{ bigip_ssh_username }}"
+#       server: "{{ ansible_host }}"
+#       server_port: "{{ bigip_ssh_port }}"
+#       password: "{{ bigip_ssh_password }}"
+#   register: result
 
-- name: Run multiple commands - provider-cli
-  bigip_command:
-    commands:
-      - tmsh show sys clock
-      - tmsh list auth
-    provider:
-      transport: cli
-      user: "{{ bigip_ssh_username }}"
-      server: "{{ ansible_host }}"
-      server_port: "{{ bigip_ssh_port }}"
-      password: "{{ bigip_ssh_password }}"
-  register: result
+# - name: Assert Run single command - provider-cli
+#   assert:
+#     that:
+#       - result.stdout_lines|length == 1
 
-- name: Assert Run multiple commands - provider-cli
-  assert:
-    that:
-      - result.stdout_lines|length == 2
+# - name: Run multiple commands - provider-cli
+#   bigip_command:
+#     commands:
+#       - tmsh show sys clock
+#       - tmsh list auth
+#     provider:
+#       transport: cli
+#       user: "{{ bigip_ssh_username }}"
+#       server: "{{ ansible_host }}"
+#       server_port: "{{ bigip_ssh_port }}"
+#       password: "{{ bigip_ssh_password }}"
+#   register: result
 
-- name: Run command missing tmsh - provider-cli
-  bigip_command:
-    commands:
-      - show sys clock
-    provider:
-      transport: cli
-      user: "{{ bigip_ssh_username }}"
-      server: "{{ ansible_host }}"
-      server_port: "{{ bigip_ssh_port }}"
-      password: "{{ bigip_ssh_password }}"
-  register: result
+# - name: Assert Run multiple commands - provider-cli
+#   assert:
+#     that:
+#       - result.stdout_lines|length == 2
 
-- name: Assert Run command missing tmsh - provider-cli
-  assert:
-    that:
-      - result.stdout_lines|length == 1
+# - name: Run command missing tmsh - provider-cli
+#   bigip_command:
+#     commands:
+#       - show sys clock
+#     provider:
+#       transport: cli
+#       user: "{{ bigip_ssh_username }}"
+#       server: "{{ ansible_host }}"
+#       server_port: "{{ bigip_ssh_port }}"
+#       password: "{{ bigip_ssh_password }}"
+#   register: result
 
-- name: Run multiple commands, one missing tmsh - provider-cli
-  bigip_command:
-    commands:
-      - tmsh show sys clock
-      - list auth
-    provider:
-      transport: cli
-      user: "{{ bigip_ssh_username }}"
-      server: "{{ ansible_host }}"
-      server_port: "{{ bigip_ssh_port }}"
-      password: "{{ bigip_ssh_password }}"
-  register: result
+# - name: Assert Run command missing tmsh - provider-cli
+#   assert:
+#     that:
+#       - result.stdout_lines|length == 1
 
-- debug:
-    msg: "{{ result.stdout_lines }}"
+# - name: Run multiple commands, one missing tmsh - provider-cli
+#   bigip_command:
+#     commands:
+#       - tmsh show sys clock
+#       - list auth
+#     provider:
+#       transport: cli
+#       user: "{{ bigip_ssh_username }}"
+#       server: "{{ ansible_host }}"
+#       server_port: "{{ bigip_ssh_port }}"
+#       password: "{{ bigip_ssh_password }}"
+#   register: result
 
-- name: Assert Run multiple commands, one missing tmsh - provider-cli
-  assert:
-    that:
-      - result.stdout_lines|length == 2
+# - debug:
+#     msg: "{{ result.stdout_lines }}"
 
-- name: Wait for something - provider-cli
-  bigip_command:
-    commands:
-      - tmsh show sys clock
-    wait_for:
-      - result[0] contains Sys::Clock
-    provider:
-      transport: cli
-      user: "{{ bigip_ssh_username }}"
-      server: "{{ ansible_host }}"
-      server_port: "{{ bigip_ssh_port }}"
-      password: "{{ bigip_ssh_password }}"
-  register: result
+# - name: Assert Run multiple commands, one missing tmsh - provider-cli
+#   assert:
+#     that:
+#       - result.stdout_lines|length == 2
 
-- name: Assert Wait for something - provider-cli
-  assert:
-    that:
-      - result.stdout_lines|length == 1
-      - "'Sys::Clock' in result.stdout[0]"
+# - name: Wait for something - provider-cli
+#   bigip_command:
+#     commands:
+#       - tmsh show sys clock
+#     wait_for:
+#       - result[0] contains Sys::Clock
+#     provider:
+#       transport: cli
+#       user: "{{ bigip_ssh_username }}"
+#       server: "{{ ansible_host }}"
+#       server_port: "{{ bigip_ssh_port }}"
+#       password: "{{ bigip_ssh_password }}"
+#   register: result
 
-- name: Run modify commands - provider-cli
-  bigip_command:
-    commands:
-      - tmsh modify sys db setup.run value true
-      - tmsh modify sys db setup.run value false
-    provider:
-      transport: cli
-      user: "{{ bigip_ssh_username }}"
-      server: "{{ ansible_host }}"
-      server_port: "{{ bigip_ssh_port }}"
-      password: "{{ bigip_ssh_password }}"
-  register: result
+# - name: Assert Wait for something - provider-cli
+#   assert:
+#     that:
+#       - result.stdout_lines|length == 1
+#       - "'Sys::Clock' in result.stdout[0]"
 
-- name: Assert Run modify commands - provider-cli
-  assert:
-    that:
-      - result.stdout_lines|length == 2
+# - name: Run modify commands - provider-cli
+#   bigip_command:
+#     commands:
+#       - tmsh modify sys db setup.run value true
+#       - tmsh modify sys db setup.run value false
+#     provider:
+#       transport: cli
+#       user: "{{ bigip_ssh_username }}"
+#       server: "{{ ansible_host }}"
+#       server_port: "{{ bigip_ssh_port }}"
+#       password: "{{ bigip_ssh_password }}"
+#   register: result
 
-- name: Run modify commands with a show command - provider-cli
-  bigip_command:
-    commands:
-      - tmsh modify sys db setup.run value true
-      - tmsh modify sys db setup.run value false
-      - tmsh show sys clock
-    provider:
-      transport: cli
-      user: "{{ bigip_ssh_username }}"
-      server: "{{ ansible_host }}"
-      server_port: "{{ bigip_ssh_port }}"
-      password: "{{ bigip_ssh_password }}"
-  register: result
+# - name: Assert Run modify commands - provider-cli
+#   assert:
+#     that:
+#       - result.stdout_lines|length == 2
 
-- name: Assert Run modify commands with a show command - provider-cli
-  assert:
-    that:
-      - result.stdout_lines|length == 3
+# - name: Run modify commands with a show command - provider-cli
+#   bigip_command:
+#     commands:
+#       - tmsh modify sys db setup.run value true
+#       - tmsh modify sys db setup.run value false
+#       - tmsh show sys clock
+#     provider:
+#       transport: cli
+#       user: "{{ bigip_ssh_username }}"
+#       server: "{{ ansible_host }}"
+#       server_port: "{{ bigip_ssh_port }}"
+#       password: "{{ bigip_ssh_password }}"
+#   register: result
 
-- import_tasks: targets/bigip_command/tasks/provider-cli/ssh-key.yaml
-  tags: provider-ssh-key
+# - name: Assert Run modify commands with a show command - provider-cli
+#   assert:
+#     that:
+#       - result.stdout_lines|length == 3
 
-- import_tasks: issue-00705.yaml
-  tags:
-    - issue-00705
-    - provider-issue-00705
+# - import_tasks: targets/bigip_command/tasks/provider-cli/ssh-key.yaml
+#   tags: provider-ssh-key
 
-- import_tasks: issue-01407.yaml
-  tags:
-    - issue-01407
-    - provider-issue-01407
+# - import_tasks: issue-00705.yaml
+#   tags:
+#     - issue-00705
+#     - provider-issue-00705
+
+# - import_tasks: issue-01407.yaml
+#   tags:
+#     - issue-01407
+#     - provider-issue-01407

--- a/test/integration/targets/bigip_command/tasks/provider-cli/main.yaml
+++ b/test/integration/targets/bigip_command/tasks/provider-cli/main.yaml
@@ -1,10 +1,9 @@
 ---
 
-- name: run show version and check to see if output contains BIG-IP
+- name: Run single command - provider-cli
   bigip_command:
-    commands: 
-      - show sys version
-    wait_for: result[0] contains BIG-IP2
+    commands:
+      - tmsh show sys version
     provider:
       transport: cli
       user: "{{ bigip_ssh_username }}"
@@ -12,147 +11,139 @@
       server_port: "{{ bigip_ssh_port }}"
       password: "{{ bigip_ssh_password }}"
   register: result
-  delegate_to: localhost
 
-# - name: Run single command - provider-cli
-#   bigip_command:
-#     commands:
-#       - tmsh show sys version
-#     provider:
-#       transport: cli
-#       user: "{{ bigip_ssh_username }}"
-#       server: "{{ ansible_host }}"
-#       server_port: "{{ bigip_ssh_port }}"
-#       password: "{{ bigip_ssh_password }}"
-#   register: result
+- name: Assert Run single command - provider-cli
+  assert:
+    that:
+      - result.stdout_lines|length == 1
 
-# - name: Assert Run single command - provider-cli
-#   assert:
-#     that:
-#       - result.stdout_lines|length == 1
+- name: Run multiple commands - provider-cli
+  bigip_command:
+    commands:
+      - tmsh show sys clock
+      - tmsh list auth
+    provider:
+      transport: cli
+      user: "{{ bigip_ssh_username }}"
+      server: "{{ ansible_host }}"
+      server_port: "{{ bigip_ssh_port }}"
+      password: "{{ bigip_ssh_password }}"
+  register: result
 
-# - name: Run multiple commands - provider-cli
-#   bigip_command:
-#     commands:
-#       - tmsh show sys clock
-#       - tmsh list auth
-#     provider:
-#       transport: cli
-#       user: "{{ bigip_ssh_username }}"
-#       server: "{{ ansible_host }}"
-#       server_port: "{{ bigip_ssh_port }}"
-#       password: "{{ bigip_ssh_password }}"
-#   register: result
+- name: Assert Run multiple commands - provider-cli
+  assert:
+    that:
+      - result.stdout_lines|length == 2
 
-# - name: Assert Run multiple commands - provider-cli
-#   assert:
-#     that:
-#       - result.stdout_lines|length == 2
+- name: Run command missing tmsh - provider-cli
+  bigip_command:
+    commands:
+      - show sys clock
+    provider:
+      transport: cli
+      user: "{{ bigip_ssh_username }}"
+      server: "{{ ansible_host }}"
+      server_port: "{{ bigip_ssh_port }}"
+      password: "{{ bigip_ssh_password }}"
+  register: result
 
-# - name: Run command missing tmsh - provider-cli
-#   bigip_command:
-#     commands:
-#       - show sys clock
-#     provider:
-#       transport: cli
-#       user: "{{ bigip_ssh_username }}"
-#       server: "{{ ansible_host }}"
-#       server_port: "{{ bigip_ssh_port }}"
-#       password: "{{ bigip_ssh_password }}"
-#   register: result
+- name: Assert Run command missing tmsh - provider-cli
+  assert:
+    that:
+      - result.stdout_lines|length == 1
 
-# - name: Assert Run command missing tmsh - provider-cli
-#   assert:
-#     that:
-#       - result.stdout_lines|length == 1
+- name: Run multiple commands, one missing tmsh - provider-cli
+  bigip_command:
+    commands:
+      - tmsh show sys clock
+      - list auth
+    provider:
+      transport: cli
+      user: "{{ bigip_ssh_username }}"
+      server: "{{ ansible_host }}"
+      server_port: "{{ bigip_ssh_port }}"
+      password: "{{ bigip_ssh_password }}"
+  register: result
 
-# - name: Run multiple commands, one missing tmsh - provider-cli
-#   bigip_command:
-#     commands:
-#       - tmsh show sys clock
-#       - list auth
-#     provider:
-#       transport: cli
-#       user: "{{ bigip_ssh_username }}"
-#       server: "{{ ansible_host }}"
-#       server_port: "{{ bigip_ssh_port }}"
-#       password: "{{ bigip_ssh_password }}"
-#   register: result
+- debug:
+    msg: "{{ result.stdout_lines }}"
 
-# - debug:
-#     msg: "{{ result.stdout_lines }}"
+- name: Assert Run multiple commands, one missing tmsh - provider-cli
+  assert:
+    that:
+      - result.stdout_lines|length == 2
 
-# - name: Assert Run multiple commands, one missing tmsh - provider-cli
-#   assert:
-#     that:
-#       - result.stdout_lines|length == 2
+- name: Wait for something - provider-cli
+  bigip_command:
+    commands:
+      - tmsh show sys clock
+    wait_for:
+      - result[0] contains Sys::Clock
+    provider:
+      transport: cli
+      user: "{{ bigip_ssh_username }}"
+      server: "{{ ansible_host }}"
+      server_port: "{{ bigip_ssh_port }}"
+      password: "{{ bigip_ssh_password }}"
+  register: result
 
-# - name: Wait for something - provider-cli
-#   bigip_command:
-#     commands:
-#       - tmsh show sys clock
-#     wait_for:
-#       - result[0] contains Sys::Clock
-#     provider:
-#       transport: cli
-#       user: "{{ bigip_ssh_username }}"
-#       server: "{{ ansible_host }}"
-#       server_port: "{{ bigip_ssh_port }}"
-#       password: "{{ bigip_ssh_password }}"
-#   register: result
+- name: Assert Wait for something - provider-cli
+  assert:
+    that:
+      - result.stdout_lines|length == 1
+      - "'Sys::Clock' in result.stdout[0]"
 
-# - name: Assert Wait for something - provider-cli
-#   assert:
-#     that:
-#       - result.stdout_lines|length == 1
-#       - "'Sys::Clock' in result.stdout[0]"
+- name: Run modify commands - provider-cli
+  bigip_command:
+    commands:
+      - tmsh modify sys db setup.run value true
+      - tmsh modify sys db setup.run value false
+    provider:
+      transport: cli
+      user: "{{ bigip_ssh_username }}"
+      server: "{{ ansible_host }}"
+      server_port: "{{ bigip_ssh_port }}"
+      password: "{{ bigip_ssh_password }}"
+  register: result
 
-# - name: Run modify commands - provider-cli
-#   bigip_command:
-#     commands:
-#       - tmsh modify sys db setup.run value true
-#       - tmsh modify sys db setup.run value false
-#     provider:
-#       transport: cli
-#       user: "{{ bigip_ssh_username }}"
-#       server: "{{ ansible_host }}"
-#       server_port: "{{ bigip_ssh_port }}"
-#       password: "{{ bigip_ssh_password }}"
-#   register: result
+- name: Assert Run modify commands - provider-cli
+  assert:
+    that:
+      - result.stdout_lines|length == 2
 
-# - name: Assert Run modify commands - provider-cli
-#   assert:
-#     that:
-#       - result.stdout_lines|length == 2
+- name: Run modify commands with a show command - provider-cli
+  bigip_command:
+    commands:
+      - tmsh modify sys db setup.run value true
+      - tmsh modify sys db setup.run value false
+      - tmsh show sys clock
+    provider:
+      transport: cli
+      user: "{{ bigip_ssh_username }}"
+      server: "{{ ansible_host }}"
+      server_port: "{{ bigip_ssh_port }}"
+      password: "{{ bigip_ssh_password }}"
+  register: result
 
-# - name: Run modify commands with a show command - provider-cli
-#   bigip_command:
-#     commands:
-#       - tmsh modify sys db setup.run value true
-#       - tmsh modify sys db setup.run value false
-#       - tmsh show sys clock
-#     provider:
-#       transport: cli
-#       user: "{{ bigip_ssh_username }}"
-#       server: "{{ ansible_host }}"
-#       server_port: "{{ bigip_ssh_port }}"
-#       password: "{{ bigip_ssh_password }}"
-#   register: result
+- name: Assert Run modify commands with a show command - provider-cli
+  assert:
+    that:
+      - result.stdout_lines|length == 3
 
-# - name: Assert Run modify commands with a show command - provider-cli
-#   assert:
-#     that:
-#       - result.stdout_lines|length == 3
+- import_tasks: targets/bigip_command/tasks/provider-cli/ssh-key.yaml
+  tags: provider-ssh-key
 
-# - import_tasks: targets/bigip_command/tasks/provider-cli/ssh-key.yaml
-#   tags: provider-ssh-key
+- import_tasks: issue-00705.yaml
+  tags:
+    - issue-00705
+    - provider-issue-00705
 
-# - import_tasks: issue-00705.yaml
-#   tags:
-#     - issue-00705
-#     - provider-issue-00705
+- import_tasks: issue-01407.yaml
+  tags:
+    - issue-01407
+    - provider-issue-01407
 
-# - import_tasks: issue-01407.yaml
-#   tags:
-#     - issue-01407
-#     - provider-issue-01407
+- import_tasks: issue-01728.yaml
+  tags:
+    - issue-01728
+    - provider-issue-01728


### PR DESCRIPTION
Fixes for bugs found with Wojciech and trying warnings for messages

Not sure how to display a warning/error without raising an error.

I tried display.warning, but that. seems to only work in Ansible plugins, not modules.

Currently, the solution is to use F5ModuleError to simplify the error displayed, and to specify that the wait_for condition has failed.