### PR TITLE
Request options when type is reset

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_policy_rule.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_policy_rule.py
@@ -693,6 +693,11 @@ class ModuleParameters(Parameters):
                 connection=True,
                 shutdown=True
             ))
+        elif 'request' in item['event']:
+            action.update(dict(
+                connection=True,
+                shutdown=True
+            ))            
 
     def _handle_persist_action(self, action, item):
         """Handle the nuances of the persist type


### PR DESCRIPTION
Add request options to reset type in bigip_policy_rule.  
Resolve https://github.com/F5Networks/f5-ansible/issues/1880