### PR TITLE
updated_vs_docs

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
@@ -21,6 +21,8 @@ options:
         if it exists. If C(present), creates the virtual server and enables it.
         If C(enabled), enables the virtual server if it exists. If C(disabled),
         creates the virtual server if needed, and sets the state to C(disabled).
+      - Attempting to change C(state) on Virtual Server that belongs to an iAPP with strict updates enabled will result
+        in error message returned by device, unless C(insert_metadata) parameter is set to C(no).
     type: str
     choices:
       - present
@@ -271,6 +273,8 @@ options:
       - Currently there is a limitation that non-admin users cannot set metadata on the object, despite being
         able to create and modify virtual server objects. Setting this option to C(no) allows
         such users to use this module to manage virtual server objects on the device.
+      - Attempting to change C(state) on Virtual Server that belongs to an iAPP with strict updates enabled will result
+        in error message returned by device, unless C(insert_metadata) parameter is set to C(no).
     type: bool
     default: yes
   address_translation:


### PR DESCRIPTION
added notes to indicate the behavior of insert_metadata and warn users of using this parameter with iApp strict updates.