### PR TITLE
Fixes #1903

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/1903-fix-mgmt-route-not-idempotent.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/1903-fix-mgmt-route-not-idempotent.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix bigip_management_route module not idempotent

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_management_route.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_management_route.py
@@ -100,7 +100,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress
 
 from ..module_utils.bigip import F5RestClient
 from ..module_utils.common import (
-    F5ModuleError, AnsibleF5Parameters, f5_argument_spec
+    F5ModuleError, AnsibleF5Parameters, f5_argument_spec, transform_name
 )
 from ..module_utils.ipaddress import is_valid_ip
 from ..module_utils.icontrol import tmos_version
@@ -322,7 +322,7 @@ class ModuleManager(object):
         uri = "https://{0}:{1}/mgmt/tm/sys/management-route/{2}".format(
             self.client.provider['server'],
             self.client.provider['server_port'],
-            self.want.name
+            transform_name(self.want.partition, self.want.name)
         )
         resp = self.client.api.get(uri)
         try:
@@ -371,7 +371,7 @@ class ModuleManager(object):
         uri = "https://{0}:{1}/mgmt/tm/sys/management-route/{2}".format(
             self.client.provider['server'],
             self.client.provider['server_port'],
-            self.want.name
+            transform_name(self.want.partition, self.want.name)
         )
         resp = self.client.api.patch(uri, json=params)
         try:
@@ -387,7 +387,7 @@ class ModuleManager(object):
         uri = "https://{0}:{1}/mgmt/tm/sys/management-route/{2}".format(
             self.client.provider['server'],
             self.client.provider['server_port'],
-            self.want.name
+            transform_name(self.want.partition, self.want.name)
         )
         response = self.client.api.delete(uri)
         if response.status == 200:
@@ -398,7 +398,7 @@ class ModuleManager(object):
         uri = "https://{0}:{1}/mgmt/tm/sys/management-route/{2}".format(
             self.client.provider['server'],
             self.client.provider['server_port'],
-            self.want.name
+            transform_name(self.want.partition, self.want.name)
         )
         resp = self.client.api.get(uri)
         try:

--- a/test/integration/targets/bigip_management_route/defaults/main.yaml
+++ b/test/integration/targets/bigip_management_route/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+
+default_gateway: 10.10.10.10
+default_network: 11.11.11.0/24
+change_gateway: 12.12.12.12
+change_network: 20.20.20.0/24

--- a/test/integration/targets/bigip_management_route/tasks/issue-01903.yaml
+++ b/test/integration/targets/bigip_management_route/tasks/issue-01903.yaml
@@ -1,0 +1,36 @@
+- name: Issue 01903 - Create a management route
+  bigip_management_route:
+    name: "{{ default_network }}"
+    description: ROUTE TO TACACS {{ default_network }}
+    gateway: "{{ default_gateway }}"
+    network: "{{ default_network }}"
+  register: result
+
+- name: Issue 01903 - Assert Create a management route
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 01903 - Create a management route - Idempotent check
+  bigip_management_route:
+    name: "{{ default_network }}"
+    description: ROUTE TO TACACS {{ default_network }}
+    gateway: "{{ default_gateway }}"
+    network: "{{ default_network }}"
+  register: result
+
+- name: Issue 01903 - Assert Create a management route - Idempotent check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 01903 - Remove management route
+  bigip_management_route:
+    name: "{{ default_network }}"
+    state: absent
+  register: result
+
+- name: Issue 01903 - Assert Remove management route
+  assert:
+    that:
+      - result is changed

--- a/test/integration/targets/bigip_management_route/tasks/main.yaml
+++ b/test/integration/targets/bigip_management_route/tasks/main.yaml
@@ -161,3 +161,6 @@
   register: result
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-01903.yaml
+  tags: issue-01903


### PR DESCRIPTION
Fixes the issue of mgmt route creation not idempotent in the case of route name containing /subnet_mask (like /32)