### PR TITLE
Treating IP address  `any` as a valid destination

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
@@ -16488,8 +16488,11 @@ class VirtualServersParameters(BaseParameters):
         # 1.1.1.1%2:80
         # /Common/1.1.1.1%2:80
         # /Common/2700:bc00:1f10:101::6%2.any
+        # /Common/any%2:80
+        # /Common/any%2.any
+        # /Common/any%2.80
         #
-        pattern = r'(?P<ip>[^%]+)%(?P<route_domain>[0-9]+)[:.](?P<port>[0-9]+|any)'
+        pattern = r'(?P<ip>[^%]+|any)%(?P<route_domain>[0-9]+)[:.](?P<port>[0-9]+|any)'
         matches = re.search(pattern, destination)
         if matches:
             try:
@@ -16500,7 +16503,7 @@ class VirtualServersParameters(BaseParameters):
                 if port == 'any':
                     port = 0
             ip = matches.group('ip')
-            if not is_valid_ip(ip):
+            if not is_valid_ip(ip) and ip.lower() != 'any':
                 raise F5ModuleError(
                     "The provided destination is not a valid IP address"
                 )
@@ -16511,11 +16514,11 @@ class VirtualServersParameters(BaseParameters):
             )
             return result
 
-        pattern = r'(?P<ip>[^%]+)%(?P<route_domain>[0-9]+)'
+        pattern = r'(?P<ip>[^%]+|any)%(?P<route_domain>[0-9]+)'
         matches = re.search(pattern, destination)
         if matches:
             ip = matches.group('ip')
-            if not is_valid_ip(ip):
+            if not is_valid_ip(ip) and ip.lower() != 'any':
                 raise F5ModuleError(
                     "The provided destination is not a valid IP address"
                 )

--- a/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_device_info.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_device_info.py
@@ -18,7 +18,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 
 from ansible_collections.f5networks.f5_modules.plugins.modules.bigip_device_info import (
-    Parameters, VirtualAddressesFactManager, ArgumentSpec, ModuleManager
+    Parameters, VirtualAddressesFactManager, ArgumentSpec, ModuleManager,
+    VirtualServersParameters
 )
 from ansible_collections.f5networks.f5_modules.tests.unit.compat import unittest
 from ansible_collections.f5networks.f5_modules.tests.unit.compat.mock import Mock, patch
@@ -61,6 +62,33 @@ class TestParameters(unittest.TestCase):
         )
         p = Parameters(params=args)
         assert p.gather_subset == ['virtual-servers']
+
+    def test_destination_1(self):
+        args = dict(
+            destination='/Common/any%2:80'
+        )
+        p = VirtualServersParameters(params=args)
+        assert p.destination_tuple.ip == 'any'
+        assert p.destination_tuple.port == 80
+        assert p.destination_tuple.route_domain == 2
+
+    def test_destination_2(self):
+        args = dict(
+            destination='/Common/any%23.any'
+        )
+        p = VirtualServersParameters(params=args)
+        assert p.destination_tuple.ip == 'any'
+        assert p.destination_tuple.port == 0
+        assert p.destination_tuple.route_domain == 23
+
+    def test_destination_3(self):
+        args = dict(
+            destination='/Common/any%24.90'
+        )
+        p = VirtualServersParameters(params=args)
+        assert p.destination_tuple.ip == 'any'
+        assert p.destination_tuple.port == 90
+        assert p.destination_tuple.route_domain == 24
 
 
 class TestManager(unittest.TestCase):

--- a/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_virtual_server.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_virtual_server.py
@@ -143,6 +143,33 @@ class TestParameters(unittest.TestCase):
         assert p.destination_tuple.port == 80
         assert p.destination_tuple.route_domain == 2
 
+    def test_destination_mutex_13(self):
+        args = dict(
+            destination='/Common/any%2:80'
+        )
+        p = ApiParameters(params=args)
+        assert p.destination_tuple.ip == 'any'
+        assert p.destination_tuple.port == 80
+        assert p.destination_tuple.route_domain == 2
+
+    def test_destination_mutex_14(self):
+        args = dict(
+            destination='/Common/any%23.any'
+        )
+        p = ApiParameters(params=args)
+        assert p.destination_tuple.ip == 'any'
+        assert p.destination_tuple.port == 0
+        assert p.destination_tuple.route_domain == 23
+
+    def test_destination_mutex_15(self):
+        args = dict(
+            destination='/Common/any%24.90'
+        )
+        p = ApiParameters(params=args)
+        assert p.destination_tuple.ip == 'any'
+        assert p.destination_tuple.port == 90
+        assert p.destination_tuple.route_domain == 24
+
     def test_module_no_partition_prefix_parameters(self):
         args = dict(
             state='present',


### PR DESCRIPTION
Some of the documentation suggests that `any` can be used as a valid destination IP address for LTM virtual servers. I can see existing configs on F5 devices that are working fine with `any` as a valid way to specify any destination. But this doesn't seem to be implemented in the ansible module. 


https://clouddocs.f5.com/cli/tmsh-reference/v14/modules/ltm/ltm-virtual.html
```
destination
	    Specifies the name of the virtual address and service on which the
	    virtual server listens for connections.

	    The format for "ipv4" is a.b.c.d[:port]. The format for an "ipv6"
	    address is a:b:c:d:e:f:g:h[.port].

	    The default value is any:any.
```
