### PR TITLE
fix for API calls to get current cert and key path on bigip

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ssl_key_cert.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ssl_key_cert.py
@@ -722,7 +722,7 @@ class ModuleManager(object):
 
             if resp.status in [200, 201] or 'code' in response and response['code'] in [200, 201]:
                 response['key_checksum'] = response['checksum']
-                response['key_source_path'] = response['sourcePath']
+                response['key_source_path'] = response['fullPath']
                 final_response = merge_two_dicts(final_response, response)
             else:
                 raise F5ModuleError(resp.content)
@@ -744,7 +744,7 @@ class ModuleManager(object):
 
             if resp.status in [200, 201] or 'code' in response and response['code'] in [200, 201]:
                 response['cert_checksum'] = response['checksum']
-                response['cert_source_path'] = response['sourcePath']
+                response['cert_source_path'] = response['fullPath']
                 final_response = merge_two_dicts(final_response, response)
             else:
                 raise F5ModuleError(resp.content)


### PR DESCRIPTION
API response in 16.0.1 returns fullPath instead of sourcePath for /mgmt/tm/sys/file/ssl-key/ and /mgmt/tm/sys/file/ssl-cert/ API requests.  This breaks the modules ability to replace an existing cert/key pair.  Change is to reference correct key in JSON from API response