### PR TITLE
Fix snat pool issue in device info module

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-snat-pool-device-info.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-snat-pool-device-info.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - Fix snat pool issue in device info module

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
@@ -16406,8 +16406,20 @@ class VirtualServersParameters(BaseParameters):
                 return 'automap'
             elif self._values['snat_type']['type'] == 'none':
                 return 'none'
-            elif self._values['snat_type']['type'] == 'pool':
+            elif self._values['snat_type']['type'] == 'snat':
                 return 'snat'
+
+    @property
+    def snat_pool(self):
+        if self._values['snat_type'] is None:
+            return None
+        if 'type' in self._values['snat_type']:
+            if self._values['snat_type']['type'] == 'automap':
+                return 'none'
+            elif self._values['snat_type']['type'] == 'none':
+                return 'none'
+            elif self._values['snat_type']['type'] == 'snat':
+                return self._values['snat_type']["pool"]
 
     @property
     def connection_mirror_enabled(self):


### PR DESCRIPTION

ok: [bigip1] => {
    "ansible_facts": {
        "ansible_net_queried": true,
        "ansible_net_virtual_servers": [
            {
                "auto_lasthop": "default",
                "availability_status": "unknown",
                "client_side_bits_in": 0,
                "client_side_bits_out": 0,
                "client_side_current_connections": 0,
                "client_side_evicted_connections": 0,
                "client_side_max_connections": 0,
                "client_side_pkts_in": 0,
                "client_side_pkts_out": 0,
                "client_side_slow_killed": 0,
                "client_side_total_connections": 0,
                "cmp_enabled": "yes",
                "cmp_mode": "all-cpus",
                "connection_limit": 0,
                "connection_mirror_enabled": "no",
                "cpu_usage_ratio_last_1_min": 0,
                "cpu_usage_ratio_last_5_min": 0,
                "cpu_usage_ratio_last_5_sec": 0,
                "current_syn_cache": 0,
                "destination": "/Common/10.0.0.1:80",
                "destination_address": "10.0.0.1",
                "destination_port": 80,
                "enabled": "yes",
                "ephemeral_bits_in": 0,
                "ephemeral_bits_out": 0,
                "ephemeral_current_connections": 0,
                "ephemeral_evicted_connections": 0,
                "ephemeral_max_connections": 0,
                "ephemeral_pkts_in": 0,
                "ephemeral_pkts_out": 0,
                "ephemeral_slow_killed": 0,
                "ephemeral_total_connections": 0,
                "full_path": "/Common/test",
                "gtm_score": 0,
                "hardware_syn_cookie_instances": 0,
                "max_conn_duration": 0,
                "mean_conn_duration": 0,
                "min_conn_duration": 0,
                "name": "test",
                "nat64_enabled": "no",
                "profiles": [
                    {
                        "context": "all",
                        "full_path": "/Common/tcp",
                        "name": "tcp"
                    }
                ],
                "protocol": "tcp",
                "rate_limit": -1,
                "rate_limit_destination_mask": 0,
                "rate_limit_mode": "object",
                "rate_limit_source_mask": 0,
                "snat_pool": "/Common/testpool",---------------------------> snat pool with type
                "snat_type": "snat",
                "software_syn_cookie_instances": 0,
                "source_address": "0.0.0.0/0",
                "source_port_behavior": "preserve",
                "status_reason": "The children pool member(s) either don't have service checking enabled, or service check results are not available yet",
                "syn_cache_overflow": 0,
                "syn_cookies_status": "not-activated",
                "total_hardware_accepted_syn_cookies": 0,
                "total_hardware_syn_cookies": 0,
                "total_requests": 0,
                "total_software_accepted_syn_cookies": 0,
                "total_software_rejected_syn_cookies": 0,
                "total_software_syn_cookies": 0,
                "translate_address": "yes",
                "translate_port": "yes",
                "type": "standard"
            }
