### PR TITLE
support --diff mode

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_firewall_address_list.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_firewall_address_list.py
@@ -752,6 +752,8 @@ class ModuleManager(object):
         self.want = ModuleParameters(params=self.module.params)
         self.have = ApiParameters()
         self.changes = UsableChanges()
+        self.before = dict()
+        self.after = dict()
 
     def _update_changed_options(self):
         diff = Difference(self.want, self.have)
@@ -764,8 +766,12 @@ class ModuleManager(object):
             else:
                 if isinstance(change, dict):
                     changed.update(change)
+                    self.before[k] = getattr(self.have, k)
+                    self.after[k] = getattr(self.want, k)
                 else:
                     changed[k] = change
+                    self.before[k] = getattr(self.have, k)
+                    self.after[k] = getattr(self.want, k)
         if changed:
             self.changes = UsableChanges(params=changed)
             return True
@@ -795,6 +801,8 @@ class ModuleManager(object):
         result.update(dict(changed=changed))
         self._announce_deprecations(result)
         send_teem(start, self.client, self.module, version)
+        diff = dict(before=self.before, after=self.after)
+        result.update(dict(diff=diff))
         return result
 
     def _announce_deprecations(self, result):


### PR DESCRIPTION
## Issue
Some modules does not support diff option

## Discussion Point
From #1473, I'm not sure the below is finished.
> this is a deliberate choice not to implement this in most modules as this will be done in stages. Some modules that have aggregates will not have diff implemented until aggregates are reworked completely, these modules are: bigip_pool_member, bigip_pool, bigip_gtm_pool_member.

However, I need --diff mode, then I created this PR.
At first, I'd like to confirm this way is okay or not. After design is fixed, I will add another modules which not support this mode in this PR