### PR TITLE
fixed bug in bigip_virtual_server that resulted incorrect partition n…

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/2103-virtual-server-profile-issue.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/2103-virtual-server-profile-issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - Fix an issue in bigip_virtual_server module that wrongly sets the partition name for profile.

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
@@ -1991,7 +1991,10 @@ class ModuleParameters(Parameters):
                 if 'name' not in profile:
                     tmp['name'] = profile
                 if 'partition' not in profile:
-                    tmp['partition'] = "Common"
+                    if len(profile["name"].split("/")) > 1:
+                        tmp["partition"] = profile["name"].split("/")[1]
+                    else:
+                        tmp['partition'] = "Common"
                 tmp['fullPath'] = fq_name(tmp['partition'], tmp['name'])
                 if not self.bypass_module_checks:
                     self._handle_ssl_profile_nuances(tmp)

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
@@ -1988,11 +1988,13 @@ class ModuleParameters(Parameters):
             if isinstance(profile, dict):
                 tmp.update(profile)
                 self._handle_profile_context(tmp)
-                if 'name' not in profile:
-                    tmp['name'] = profile
+                tmp['name'] = profile
+                if 'name' in profile:
+                    tmp['name'] = profile['name']
                 if 'partition' not in profile:
-                    if len(profile["name"].split("/")) > 1:
-                        tmp["partition"] = profile["name"].split("/")[1]
+                    if isinstance(tmp['name'], str) and len(tmp["name"].split("/")) > 1:
+                        tmp["partition"] = tmp["name"].split("/")[1]
+                        tmp['name'] = os.path.basename(tmp['name'])
                     else:
                         tmp['partition'] = "Common"
                 tmp['fullPath'] = fq_name(tmp['partition'], tmp['name'])

--- a/test/integration/targets/bigip_virtual_server/tasks/environment/issue-02103.yaml
+++ b/test/integration/targets/bigip_virtual_server/tasks/environment/issue-02103.yaml
@@ -1,0 +1,52 @@
+---
+
+- name: Issue 02103 - Add virtual server with profiles having client/server context
+  bigip_virtual_server:
+      name: issue-02103
+      destination: 1.2.3.4
+      port: 80
+      partition: out_ssl
+      state: present
+      profiles:
+      - context: serverside
+        name: /out_ssl/serverssl
+      - context: clientside
+        name: /out_ssl/clientssl
+  register: result
+
+- name: Issue 02103 - Assert Add virtual server with profiles having client/server context
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02103 - Add virtual server with profiles having client/server context - Idempotent Check
+  bigip_virtual_server:
+      name: issue-02103
+      destination: 1.2.3.4
+      port: 80
+      partition: out_ssl
+      state: present
+      profiles:
+      - context: serverside
+        name: /out_ssl/serverssl
+      - context: clientside
+        name: /out_ssl/clientssl
+  register: result
+
+- name: Issue 02103 - Assert Add virtual server with profiles having client/server context - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Remove virtual server with profiles having client/server context
+  bigip_virtual_server:
+    name: issue-02103
+    destination: 1.2.3.4
+    partition: out_ssl
+    state: absent
+  register: result
+
+- name: Issue 02103 - Assert Remove virtual server having profiles with client/server context
+  assert:
+    that:
+      - result is changed

--- a/test/integration/targets/bigip_virtual_server/tasks/environment/main.yaml
+++ b/test/integration/targets/bigip_virtual_server/tasks/environment/main.yaml
@@ -111,6 +111,9 @@
 - import_tasks: issue-00805.yaml
   tags: issue-00805
 
+- import_tasks: issue-02103.yaml
+  tags: issue-02103
+
 - import_tasks: issue-02104.yaml
   tags: issue-02104
 


### PR DESCRIPTION
Fixes #2103 

```
ansible-playbook -i inventory/hosts ../f5-ansible/test/integration/bigip_virtual_server.yaml -t "issue-02103"


PLAY [Metadata of bigip_virtual_server] ****************************************

PLAY [Test the bigip_virtual_server module - Environment] **********************

TASK [Gathering Facts] *********************************************************
ok: [bigip1]

TASK [bigip_virtual_server : Issue 02103 - Add virtual server with profiles having client/server context] ***
changed: [bigip1]

TASK [bigip_virtual_server : Issue 02103 - Assert Add virtual server with profiles having client/server context] ***
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_virtual_server : Issue 02103 - Add virtual server with profiles having client/server context - Idempotent Check] ***
ok: [bigip1]

TASK [bigip_virtual_server : Issue 02103 - Assert Add virtual server with profiles having client/server context - Idempotent Check] ***
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_virtual_server : Remove virtual server with profiles having client/server context] ***
changed: [bigip1]

TASK [bigip_virtual_server : Issue 02103 - Assert Remove virtual server having profiles with client/server context] ***
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY [Test the bigip_virtual_server module - Provider] *************************

TASK [Gathering Facts] *********************************************************
ok: [bigip1]

PLAY RECAP *********************************************************************
bigip1                     : ok=8    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```