### PR TITLE
fixed bug in bigip_command module related to interpretation of pipe

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/bugfix-bigip-command.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/bugfix-bigip-command.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - bigip_command - fixed a bug that interpreted a pipe symbol inside an input string as pipe used to combine commands.

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
@@ -205,6 +205,7 @@ warn:
 
 import copy
 import re
+import shlex
 import time
 from datetime import datetime
 
@@ -284,6 +285,12 @@ class Parameters(AnsibleF5Parameters):
             result = self._values['commands']
         return result
 
+    def cmd_has_pipe(self, cmd):
+        lex = shlex.shlex(cmd, posix=True)
+        lex.whitespace = '|'
+        lex.whitespace_split = True
+        return len(list(lex)) > 1
+
     def convert_commands(self, commands):
         result = []
         for command in commands:
@@ -293,7 +300,7 @@ class Parameters(AnsibleF5Parameters):
             )
 
             command = command.replace("'", "\\'")
-            pipeline = command.split('|', 1)
+            pipeline = command.split('|', 1) if self.cmd_has_pipe(command) else [command]
             tmp['command'] = pipeline[0]
             try:
                 tmp['pipeline'] = pipeline[1]
@@ -310,7 +317,7 @@ class Parameters(AnsibleF5Parameters):
                 pipeline=''
             )
 
-            pipeline = command.split('|', 1)
+            pipeline = command.split('|', 1) if self.cmd_has_pipe(command) else [command]
             tmp['command'] = pipeline[0]
             try:
                 tmp['pipeline'] = pipeline[1]

--- a/test/integration/targets/bigip_command/tasks/environment/handle-pipe.yaml
+++ b/test/integration/targets/bigip_command/tasks/environment/handle-pipe.yaml
@@ -1,0 +1,38 @@
+---
+
+- name: Create http-compression profile
+  bigip_profile_http_compression:
+    name: Xcompression
+    state: present
+  register: result
+
+- name: Assert - Create http-compression profile
+  assert:
+    that:
+      result is success
+
+- name: Test command that has a pipe
+  bigip_command:
+    commands:
+      - modify ltm profile http-compression Xcompression content-type-include add { "image/(photoshop\|psd\|x-photoshop\|x-vsd)" }
+      - show ltm profile http-compression Xcompression | nl
+      - show ltm profile http-compression Xcompression | wc -l
+  register: result
+
+- name: Assert - Test command that has a pipe
+  assert:
+    that:
+      - result is success
+      - "'Error' not in result.stdout"
+
+- name: Delete http-compression profile
+  bigip_profile_http_compression:
+    name: Xcompression
+    state: absent
+
+- name: Assert - Delete http-compression profile
+  assert:
+    that:
+      result is success
+
+...

--- a/test/integration/targets/bigip_command/tasks/environment/main.yaml
+++ b/test/integration/targets/bigip_command/tasks/environment/main.yaml
@@ -124,3 +124,6 @@
 
 - import_tasks: issue-00785.yaml
   tags: issue-00785
+
+- import_tasks: handle-pipe.yaml
+  tags: handle-pipe.yaml


### PR DESCRIPTION
```
(venv-3.9) ➜ ansible-playbook ../f5-ansible/test/integration/bigip_command.yaml -t "environment" --step

PLAY [Metadata of bigip_command] *********************************************************************************************************************************

PLAY [Test the bigip_command module - Environment] ***************************************************************************************************************
Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: y

Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: *******************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************************************************
ok: [bigip1]
Perform task: TASK: bigip_command : Create http-compression profile (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_command : Create http-compression profile (N)o/(y)es/(c)ontinue: ***********************************************************************

TASK [bigip_command : Create http-compression profile] ***********************************************************************************************************
changed: [bigip1]
Perform task: TASK: bigip_command : Assert - Create http-compression profile (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_command : Assert - Create http-compression profile (N)o/(y)es/(c)ontinue: **************************************************************

TASK [bigip_command : Assert - Create http-compression profile] **************************************************************************************************
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}
Perform task: TASK: bigip_command : Test command that has a pipe (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_command : Test command that has a pipe (N)o/(y)es/(c)ontinue: **************************************************************************

TASK [bigip_command : Test command that has a pipe] **************************************************************************************************************
[WARNING]: Using "write" commands is not idempotent. You should use a module that is specifically made for that. If such a module does not exist, then please
file a bug. The command in question is "modify ltm profile http-compression Xcom..."
changed: [bigip1]
Perform task: TASK: bigip_command : Assert - Test command that has a pipe (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_command : Assert - Test command that has a pipe (N)o/(y)es/(c)ontinue: *****************************************************************

TASK [bigip_command : Assert - Test command that has a pipe] *****************************************************************************************************
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}
Perform task: TASK: bigip_command : Delete http-compression profile (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_command : Delete http-compression profile (N)o/(y)es/(c)ontinue: ***********************************************************************

TASK [bigip_command : Delete http-compression profile] ***********************************************************************************************************
changed: [bigip1]
Perform task: TASK: bigip_command : Assert - Delete http-compression profile (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_command : Assert - Delete http-compression profile (N)o/(y)es/(c)ontinue: **************************************************************

TASK [bigip_command : Assert - Delete http-compression profile] **************************************************************************************************
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY [Test the bigip_command module - Provider-cli] **************************************************************************************************************
Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: y

Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: *******************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************************************************
ok: [bigip1]

PLAY [Test the bigip_command module - Provider-rest] *************************************************************************************************************
Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: y

Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: *******************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************************************************
ok: [bigip1]

PLAY RECAP *******************************************************************************************************************************************************
bigip1                     : ok=9    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```