### PR TITLE
Added parent to the data gathered for serversslprofile

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/2170-add-parent-in-serversslprofile.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/2170-add-parent-in-serversslprofile.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - bigip_device_info - add parent to the data gathered for ServerSSL Profiles

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
@@ -13825,6 +13825,7 @@ class ServerSslProfilesParameters(BaseParameters):
         'cacheTimeout': 'cache_timeout',
         'cipherGroup': 'cipher_group',
         'crlFile': 'crl_file',
+        'defaultsFrom': 'parent',
         'expireCertResponseControl': 'expire_cert_response_control',
         'genericAlert': 'generic_alert',
         'handshakeTimeout': 'handshake_timeout',

--- a/test/integration/targets/bigip_device_info/tasks/issue-02170.yaml
+++ b/test/integration/targets/bigip_device_info/tasks/issue-02170.yaml
@@ -1,0 +1,11 @@
+---
+- name: Gather ServerSSL Profile Info
+  bigip_device_info:
+    gather_subset:
+      - "server-ssl-profiles"
+  register: result
+
+- name: Check parent profile
+  assert:
+    that:
+      - '"parent" in {{ result.ansible_facts.ansible_net_server_ssl_profiles[0] }}'

--- a/test/integration/targets/bigip_device_info/tasks/main.yaml
+++ b/test/integration/targets/bigip_device_info/tasks/main.yaml
@@ -535,3 +535,6 @@
 
 - import_tasks: issue-02123.yaml
   tags: issue-02123
+
+- import_tasks: issue-02170.yaml
+  tags: issue-02170


### PR DESCRIPTION
Fixes #2170

```
ansible-playbook ../f5-ansible/test/integration/bigip_device_info.yaml -t "issue-02170"

PLAY [Metadata of bigip_device_info] *****************************************************************************************************************************

PLAY [Test the bigip_device_info module] *************************************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************************************************
ok: [bigip1]

TASK [bigip_device_info : Gather ServerSSL Profile Info] *********************************************************************************************************
ok: [bigip1]

TASK [bigip_device_info : Check parent profile] ******************************************************************************************************************
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY RECAP *******************************************************************************************************************************************************
bigip1                     : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```