### PR TITLE
added support for "up_interval" to HTTP monitor module.

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_http.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_http.py
@@ -100,6 +100,15 @@ options:
         C(time_until_up) is specified, it must be C(0). Or, if it already exists, it
         must be C(0).
     type: bool
+  up_interval:
+    description:
+      - Specifies the interval for the system to use to perform the health check
+        when a resource is up.
+      - When C(0), specifies the system uses the interval specified in
+        C(interval) to check the health of the resource.
+      - When any other number, enables you to specify a different interval
+        when checking the health of a resource that is up.
+    type: int
   partition:
     description:
       - Device partition to manage resources on.
@@ -193,6 +202,11 @@ reverse:
   returned: changed
   type: bool
   sample: yes
+up_interval:
+  description: Interval for the system to use to perform the health check when a resource is up.
+  returned: changed
+  type: int
+  sample: 0
 '''
 from datetime import datetime
 
@@ -216,6 +230,7 @@ class Parameters(AnsibleF5Parameters):
         'defaultsFrom': 'parent',
         'recv': 'receive',
         'recvDisable': 'receive_disable',
+        'upInterval': 'up_interval',
     }
 
     api_attributes = [
@@ -231,6 +246,7 @@ class Parameters(AnsibleF5Parameters):
         'recvDisable',
         'description',
         'reverse',
+        'upInterval',
     ]
 
     returnables = [
@@ -245,6 +261,7 @@ class Parameters(AnsibleF5Parameters):
         'receive_disable',
         'description',
         'reverse',
+        'up_interval',
     ]
 
     updatables = [
@@ -259,6 +276,7 @@ class Parameters(AnsibleF5Parameters):
         'receive_disable',
         'description',
         'reverse',
+        'up_interval',
     ]
 
     @property
@@ -705,6 +723,7 @@ class ArgumentSpec(object):
             receive=dict(),
             receive_disable=dict(),
             ip=dict(),
+            up_interval=dict(type='int'),
             port=dict(),
             interval=dict(type='int'),
             reverse=dict(type='bool'),


### PR DESCRIPTION
Added support to the HTTP monitor module for the 'up_interval' setting.

I verified this worked against a test instance of 16.1.2.1 we manage. 