### PR TITLE
Fix example on bigip_remote_role

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_remote_role.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_remote_role.py
@@ -96,11 +96,10 @@ author:
 EXAMPLES = r'''
 - name: Create a remote role
   bigip_remote_role:
-    name: foo
-    group_name: ldap_group
+    name: ldap_group
     line_order: 1
     attribute_string: memberOf=cn=ldap_group,cn=ldap.group,ou=ldap
-    remote_access: enabled
+    remote_access: yes
     assigned_role: administrator
     partition_access: all
     terminal_access: none


### PR DESCRIPTION
group_name is not supported.
remote_access is a yes or a no.