### PR TITLE
fix for extracting ip from destination in ltm and gtm monitors

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-ip-extraction_ltm_gtm_monitor.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-ip-extraction_ltm_gtm_monitor.yaml
@@ -1,0 +1,19 @@
+---
+bugfixes:
+    - bigip_gtm_monitor_bigip - fixed bug related to ip extraction from monitor.
+    - bigip_gtm_monitor_external - fixed bug related to ip extraction from monitor.
+    - bigip_gtm_monitor_firepass - fixed bug related to ip extraction from monitor.
+    - bigip_gtm_monitor_http - fixed bug related to ip extraction from monitor.
+    - bigip_gtm_monitor_https - fixed bug related to ip extraction from monitor.
+    - bigip_gtm_monitor_tcp - fixed bug related to ip extraction from monitor.
+    - bigip_gtm_monitor_tcp_half_open - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_dns - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_external - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_ftp - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_gateway_icmp - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_ldap - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_mysql - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_oracle - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_smtp - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_tcp - fixed bug related to ip extraction from monitor.
+    - bigip_monitor_udp - fixed bug related to ip extraction from monitor.

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_bigip.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_bigip.py
@@ -263,13 +263,25 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        return int(port)
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def ignore_down_response(self):

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_external.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_external.py
@@ -208,7 +208,9 @@ class Parameters(AnsibleF5Parameters):
 
     @destination.setter
     def destination(self, value):
-        ip, port = value.split(':')
+        ip, d, port = value.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = value.rpartition(':')
         self._values['ip'] = ip
         self._values['port'] = port
 

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_firepass.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_firepass.py
@@ -305,16 +305,25 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
         try:
-            return int(port)
+            ip, d, port = self._values['destination'].rpartition(':')
         except ValueError:
-            return port
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def ignore_down_response(self):
@@ -427,13 +436,25 @@ class UsableChanges(Changes):
 class ReportableChanges(Changes):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        return int(port)
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def ignore_down_response(self):

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_http.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_http.py
@@ -313,16 +313,25 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
         try:
-            return int(port)
+            ip, d, port = self._values['destination'].rpartition(':')
         except ValueError:
-            return port
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def ignore_down_response(self):
@@ -459,13 +468,25 @@ class UsableChanges(Changes):
 class ReportableChanges(Changes):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        return int(port)
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def transparent(self):

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_https.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_https.py
@@ -370,16 +370,25 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
         try:
-            return int(port)
+            ip, d, port = self._values['destination'].rpartition(':')
         except ValueError:
-            return port
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def ignore_down_response(self):
@@ -554,13 +563,25 @@ class UsableChanges(Changes):
 class ReportableChanges(Changes):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        return int(port)
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def transparent(self):

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_tcp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_tcp.py
@@ -288,16 +288,25 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
         try:
-            return int(port)
+            ip, d, port = self._values['destination'].rpartition(':')
         except ValueError:
-            return port
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def ignore_down_response(self):
@@ -433,13 +442,25 @@ class UsableChanges(Changes):
 class ReportableChanges(Changes):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        return int(port)
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def transparent(self):

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_tcp_half_open.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_gtm_monitor_tcp_half_open.py
@@ -275,13 +275,25 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        return int(port)
+        try:
+            ip, d, port = self._values['destination'].rpartition(':')
+        except ValueError:
+            try:
+                ip, d, port = self._values['destination'].rpartition('.')
+            except ValueError as ex:
+                raise F5ModuleError(str(ex))
+        return int(port) if port.isnumeric() else port
 
     @property
     def ignore_down_response(self):

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_dns.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_dns.py
@@ -478,7 +478,9 @@ class Parameters(AnsibleF5Parameters):
 
     @destination.setter
     def destination(self, value):
-        ip, port = value.split(':')
+        ip, d, port = value.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = value.rpartition(':')
         self._values['ip'] = ip
         self._values['port'] = port
 

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_external.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_external.py
@@ -235,7 +235,9 @@ class Parameters(AnsibleF5Parameters):
 
     @destination.setter
     def destination(self, value):
-        ip, port = value.split(':')
+        ip, d, port = value.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = value.rpartition(':')
         self._values['ip'] = ip
         self._values['port'] = port
 

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_ftp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_ftp.py
@@ -348,16 +348,19 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        try:
-            return int(port)
-        except ValueError:
-            return port
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
+        return int(port) if port.isnumeric() else port
 
     @property
     def description(self):

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_gateway_icmp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_gateway_icmp.py
@@ -344,7 +344,9 @@ class Parameters(AnsibleF5Parameters):
 
     @destination.setter
     def destination(self, value):
-        ip, port = value.split(':')
+        ip, d, port = value.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = value.rpartition(':')
         self._values['ip'] = ip
         self._values['port'] = port
 

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_ldap.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_ldap.py
@@ -349,16 +349,19 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        try:
-            return int(port)
-        except ValueError:
-            return port
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
+        return int(port) if port.isnumeric() else port
 
     @property
     def description(self):
@@ -473,15 +476,19 @@ class ReportableChanges(Changes):
 
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        if port == '*':
-            return port
-        return int(port)
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
+        return int(port) if port.isnumeric() else port
 
 
 class Difference(object):

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_mysql.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_mysql.py
@@ -399,26 +399,18 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        try:
-            ip, port = self._values['destination'].split(':')
-        except ValueError:
-            # in version 15 wildcard changed this to have . instead of : as separator for wildcard
-            try:
-                ip, port = self._values['destination'].split('.')
-            except ValueError as ex:
-                raise F5ModuleError(str(ex))
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return ip
 
     @property
     def port(self):
-        try:
-            ip, port = self._values['destination'].split(':')
-        except ValueError:
-            # in version 15 wildcard changed this to have . instead of : as separator for wildcard
-            try:
-                ip, port = self._values['destination'].split('.')
-            except ValueError as ex:
-                raise F5ModuleError(str(ex))
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return port
 
     @property
@@ -549,12 +541,18 @@ class UsableChanges(Changes):
 class ReportableChanges(Changes):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return int(port)
 
     @property

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_oracle.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_oracle.py
@@ -403,26 +403,18 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        try:
-            ip, port = self._values['destination'].split(':')
-        except ValueError:
-            # in version 15 wildcard changed this to have . instead of : as separator for wildcard
-            try:
-                ip, port = self._values['destination'].split('.')
-            except ValueError as ex:
-                raise F5ModuleError(str(ex))
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return ip
 
     @property
     def port(self):
-        try:
-            ip, port = self._values['destination'].split(':')
-        except ValueError:
-            # in version 15 wildcard changed this to have . instead of : as separator for wildcard
-            try:
-                ip, port = self._values['destination'].split('.')
-            except ValueError as ex:
-                raise F5ModuleError(str(ex))
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return port
 
     @property

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_smtp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_smtp.py
@@ -295,16 +295,19 @@ class Parameters(AnsibleF5Parameters):
 class ApiParameters(Parameters):
     @property
     def ip(self):
-        ip, port = self._values['destination'].split(':')
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
         return ip
 
     @property
     def port(self):
-        ip, port = self._values['destination'].split(':')
-        try:
-            return int(port)
-        except ValueError:
-            return port
+        des = self._values['destination']
+        ip, d, port = des.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = des.rpartition(':')
+        return int(port) if port.isnumeric() else port
 
     @property
     def description(self):

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_tcp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_tcp.py
@@ -308,7 +308,9 @@ class Parameters(AnsibleF5Parameters):
 
     @destination.setter
     def destination(self, value):
-        ip, port = value.split(':')
+        ip, d, port = value.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = value.rpartition(':')
         self._values['ip'] = ip
         self._values['port'] = port
 

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_tcp_half_open.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_tcp_half_open.py
@@ -216,7 +216,9 @@ class Parameters(AnsibleF5Parameters):
 
     @destination.setter
     def destination(self, value):
-        ip, port = value.split(':')
+        ip, d, port = value.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = value.rpartition(':')
         self._values['ip'] = ip
         self._values['port'] = port
 

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_udp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_monitor_udp.py
@@ -224,7 +224,9 @@ class Parameters(AnsibleF5Parameters):
 
     @destination.setter
     def destination(self, value):
-        ip, port = value.split(':')
+        ip, d, port = value.rpartition('.')
+        if not is_valid_ip(ip) and ip != '*':
+            ip, d, port = value.rpartition(':')
         self._values['ip'] = ip
         self._values['port'] = port
 

--- a/test/integration/targets/bigip_gtm_monitor_bigip/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_bigip/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create GTM BigIP Monitor
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM BigIP Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create GTM BigIP Monitor - Idempotent Check
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM BigIP Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade GTM BigIP Monitor with IPv4
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM BigIP Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade GTM BigIP Monitor with IPv4 - Idempotent Check
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM BigIP Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update GTM BigIP Monitor with IPv6
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM BigIP Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM BigIP Monitor with IPv6 - Idempotent Check
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM BigIP Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update GTM BigIP Monitor with IP as *
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM BigIP Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM BigIP Monitor with IP as * - Idempotent Check
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM BigIP Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete GTM BigIP Monitor
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM BigIP monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete GTM BigIP Monitor - Idempotent Check
+  bigip_gtm_monitor_bigip:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM BigIP monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_gtm_monitor_bigip/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_bigip/tasks/main.yaml
@@ -284,3 +284,6 @@
   tags: issue-01074
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags: issue-02163

--- a/test/integration/targets/bigip_gtm_monitor_external/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_external/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create GTM External Monitor
+  bigip_gtm_monitor_external:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM External Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create GTM External Monitor - Idempotent Check
+  bigip_gtm_monitor_external:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM External Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade GTM External Monitor with IPv4
+  bigip_gtm_monitor_external:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM External Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade GTM External Monitor with IPv4 - Idempotent Check
+  bigip_gtm_monitor_external:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM External Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update GTM External Monitor with IPv6
+  bigip_gtm_monitor_external:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM External Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM External Monitor with IPv6 - Idempotent Check
+  bigip_gtm_monitor_external:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM External Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update GTM External Monitor with IP as *
+  bigip_gtm_monitor_external:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM External Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM External Monitor with IP as * - Idempotent Check
+  bigip_gtm_monitor_external:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM External Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete GTM External Monitor
+  bigip_gtm_monitor_external:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM External monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete GTM External Monitor - Idempotent Check
+  bigip_gtm_monitor_external:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM External monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_gtm_monitor_external/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_external/tasks/main.yaml
@@ -331,3 +331,6 @@
   tags: issue-01074
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags: issue-02163

--- a/test/integration/targets/bigip_gtm_monitor_firepass/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_firepass/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create GTM Firepass Monitor
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM Firepass Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create GTM Firepass Monitor - Idempotent Check
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM Firepass Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade GTM Firepass Monitor with IPv4
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM Firepass Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade GTM Firepass Monitor with IPv4 - Idempotent Check
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM Firepass Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update GTM Firepass Monitor with IPv6
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM Firepass Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM Firepass Monitor with IPv6 - Idempotent Check
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM Firepass Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update GTM Firepass Monitor with IP as *
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM Firepass Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM Firepass Monitor with IP as * - Idempotent Check
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM Firepass Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete GTM Firepass Monitor
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM Firepass monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete GTM Firepass Monitor - Idempotent Check
+  bigip_gtm_monitor_firepass:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM Firepass monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_gtm_monitor_firepass/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_firepass/tasks/main.yaml
@@ -339,3 +339,6 @@
   tags: issue-01074
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags: issue-02163

--- a/test/integration/targets/bigip_gtm_monitor_http/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_http/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create GTM HTTP Monitor
+  bigip_gtm_monitor_http:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM HTTP Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create GTM HTTP Monitor - Idempotent Check
+  bigip_gtm_monitor_http:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM HTTP Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade GTM HTTP Monitor with IPv4
+  bigip_gtm_monitor_http:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTP Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade GTM HTTP Monitor with IPv4 - Idempotent Check
+  bigip_gtm_monitor_http:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTP Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update GTM HTTP Monitor with IPv6
+  bigip_gtm_monitor_http:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTP Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM HTTP Monitor with IPv6 - Idempotent Check
+  bigip_gtm_monitor_http:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTP Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update GTM HTTP Monitor with IP as *
+  bigip_gtm_monitor_http:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTP Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM HTTP Monitor with IP as * - Idempotent Check
+  bigip_gtm_monitor_http:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTP Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete GTM HTTP Monitor
+  bigip_gtm_monitor_http:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM HTTP monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete GTM HTTP Monitor - Idempotent Check
+  bigip_gtm_monitor_http:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM HTTP monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_gtm_monitor_http/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_http/tasks/main.yaml
@@ -415,3 +415,6 @@
   tags: issue-01074
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags: issue-02163

--- a/test/integration/targets/bigip_gtm_monitor_https/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_https/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create GTM HTTPS Monitor
+  bigip_gtm_monitor_https:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM HTTPS Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create GTM HTTPS Monitor - Idempotent Check
+  bigip_gtm_monitor_https:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM HTTPS Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade GTM HTTPS Monitor with IPv4
+  bigip_gtm_monitor_https:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTPS Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade GTM HTTPS Monitor with IPv4 - Idempotent Check
+  bigip_gtm_monitor_https:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTPS Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update GTM HTTPS Monitor with IPv6
+  bigip_gtm_monitor_https:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTPS Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM HTTPS Monitor with IPv6 - Idempotent Check
+  bigip_gtm_monitor_https:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTPS Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update GTM HTTPS Monitor with IP as *
+  bigip_gtm_monitor_https:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTPS Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM HTTPS Monitor with IP as * - Idempotent Check
+  bigip_gtm_monitor_https:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM HTTPS Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete GTM HTTPS Monitor
+  bigip_gtm_monitor_https:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM HTTPS monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete GTM HTTPS Monitor - Idempotent Check
+  bigip_gtm_monitor_https:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM HTTPS monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_gtm_monitor_https/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_https/tasks/main.yaml
@@ -569,3 +569,6 @@
   tags: issue-01074
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags: issue-02163

--- a/test/integration/targets/bigip_gtm_monitor_tcp/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_tcp/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create GTM TCP Monitor
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM TCP Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create GTM TCP Monitor - Idempotent Check
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM TCP Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade GTM TCP Monitor with IPv4
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade GTM TCP Monitor with IPv4 - Idempotent Check
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update GTM TCP Monitor with IPv6
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM TCP Monitor with IPv6 - Idempotent Check
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update GTM TCP Monitor with IP as *
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM TCP Monitor with IP as * - Idempotent Check
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete GTM TCP Monitor
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM TCP monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete GTM TCP Monitor - Idempotent Check
+  bigip_gtm_monitor_tcp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM TCP monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_gtm_monitor_tcp/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_tcp/tasks/main.yaml
@@ -370,3 +370,6 @@
   tags: issue-01074
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags: issue-02163

--- a/test/integration/targets/bigip_gtm_monitor_tcp_half_open/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_tcp_half_open/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create GTM TCP Half Open Monitor
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM TCP Half Open Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create GTM TCP Half Open Monitor - Idempotent Check
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create GTM TCP Half Open Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade GTM TCP Half Open Monitor with IPv4
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Half Open Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade GTM TCP Half Open Monitor with IPv4 - Idempotent Check
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Half Open Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update GTM TCP Half Open Monitor with IPv6
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Half Open Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM TCP Half Open Monitor with IPv6 - Idempotent Check
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Half Open Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update GTM TCP Half Open Monitor with IP as *
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Half Open Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update GTM TCP Half Open Monitor with IP as * - Idempotent Check
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade GTM TCP Half Open Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete GTM TCP Half Open Monitor
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM TCP Half Open monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete GTM TCP Half Open Monitor - Idempotent Check
+  bigip_gtm_monitor_tcp_half_open:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete GTM TCP Half Open monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_gtm_monitor_tcp_half_open/tasks/main.yaml
+++ b/test/integration/targets/bigip_gtm_monitor_tcp_half_open/tasks/main.yaml
@@ -262,3 +262,6 @@
   tags: issue-01074
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags: issue-02163

--- a/test/integration/targets/bigip_monitor_dns/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_dns/tasks/issue-02163.yaml
@@ -1,0 +1,124 @@
+---
+- name: Issue 02163 - Create DNS Monitor
+  bigip_monitor_dns:
+    name: infra_791
+    query_name: "{{ query_name1 }}"
+  register: result
+
+- name: Issue 02163 - Assert Create DNS Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create DNS Monitor - Idempotent Check
+  bigip_monitor_dns:
+    name: infra_791
+    query_name: "{{ query_name1 }}"
+  register: result
+
+- name: Issue 02163 - Assert Create DNS Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade DNS Monitor with IPv4
+  bigip_monitor_dns:
+    name: infra_791
+    query_name: "{{ query_name1 }}"
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade DNS Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade DNS Monitor with IPv4 - Idempotent Check
+  bigip_monitor_dns:
+    name: infra_791
+    query_name: "{{ query_name1 }}"
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade DNS Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update DNS Monitor with IPv6
+  bigip_monitor_dns:
+    name: infra_791
+    query_name: "{{ query_name1 }}"
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade DNS Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update DNS Monitor with IPv6 - Idempotent Check
+  bigip_monitor_dns:
+    name: infra_791
+    query_name: "{{ query_name1 }}"
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade DNS Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update DNS Monitor with IP as *
+  bigip_monitor_dns:
+    name: infra_791
+    query_name: "{{ query_name1 }}"
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade DNS Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update DNS Monitor with IP as * - Idempotent Check
+  bigip_monitor_dns:
+    name: infra_791
+    query_name: "{{ query_name1 }}"
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade DNS Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete DNS Monitor
+  bigip_monitor_dns:
+    name: infra_791
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete DNS monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete DNS Monitor - Idempotent Check
+  bigip_monitor_dns:
+    name: infra_791
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete DNS monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_dns/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_dns/tasks/main.yaml
@@ -846,4 +846,8 @@
   tags:
     - issue-01074
 
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163
+
 - import_tasks: teardown.yaml

--- a/test/integration/targets/bigip_monitor_external/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_external/tasks/issue-02163.yaml
@@ -1,0 +1,116 @@
+---
+- name: Issue 02163 - Create External Monitor
+  bigip_monitor_external:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create External Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create External Monitor - Idempotent Check
+  bigip_monitor_external:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create External Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade External Monitor with IPv4
+  bigip_monitor_external:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade External Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade External Monitor with IPv4 - Idempotent Check
+  bigip_monitor_external:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade External Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update External Monitor with IPv6
+  bigip_monitor_external:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade External Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update External Monitor with IPv6 - Idempotent Check
+  bigip_monitor_external:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade External Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update External Monitor with IP as *
+  bigip_monitor_external:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade External Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update External Monitor with IP as * - Idempotent Check
+  bigip_monitor_external:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade External Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete External Monitor
+  bigip_monitor_external:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete External monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete External Monitor - Idempotent Check
+  bigip_monitor_external:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete External monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_external/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_external/tasks/main.yaml
@@ -340,3 +340,7 @@
 - import_tasks: issue-01074.yaml
   tags:
     - issue-01074
+
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163

--- a/test/integration/targets/bigip_monitor_ftp/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_ftp/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create FTP Monitor
+  bigip_monitor_ftp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create FTP Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create FTP Monitor - Idempotent Check
+  bigip_monitor_ftp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create FTP Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade FTP Monitor with IPv4
+  bigip_monitor_ftp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade FTP Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade FTP Monitor with IPv4 - Idempotent Check
+  bigip_monitor_ftp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade FTP Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update FTP Monitor with IPv6
+  bigip_monitor_ftp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade FTP Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update FTP Monitor with IPv6 - Idempotent Check
+  bigip_monitor_ftp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade FTP Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update FTP Monitor with IP as *
+  bigip_monitor_ftp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade FTP Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update FTP Monitor with IP as * - Idempotent Check
+  bigip_monitor_ftp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade FTP Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete FTP Monitor
+  bigip_monitor_ftp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete FTP monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete FTP Monitor - Idempotent Check
+  bigip_monitor_ftp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete FTP monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_ftp/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_ftp/tasks/main.yaml
@@ -186,4 +186,8 @@
     name: "{{ monitor_name2 }}"
     state: absent
 
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163
+
 - import_tasks: teardown.yaml

--- a/test/integration/targets/bigip_monitor_gateway_icmp/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_gateway_icmp/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create ICMP Monitor
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create ICMP Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create ICMP Monitor - Idempotent Check
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create ICMP Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade ICMP Monitor with IPv4
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade ICMP Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade ICMP Monitor with IPv4 - Idempotent Check
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade ICMP Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update ICMP Monitor with IPv6
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade ICMP Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update ICMP Monitor with IPv6 - Idempotent Check
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade ICMP Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update ICMP Monitor with IP as *
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade ICMP Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update ICMP Monitor with IP as * - Idempotent Check
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade ICMP Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete ICMP Monitor
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete ICMP monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete ICMP Monitor - Idempotent Check
+  bigip_monitor_gateway_icmp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete ICMP monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_gateway_icmp/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_gateway_icmp/tasks/main.yaml
@@ -532,3 +532,7 @@
 - import_tasks: issue-01074.yaml
   tags:
     - issue-01074
+
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163

--- a/test/integration/targets/bigip_monitor_ldap/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_ldap/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create LDAP Monitor
+  bigip_monitor_ldap:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create LDAP Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create LDAP Monitor - Idempotent Check
+  bigip_monitor_ldap:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create LDAP Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade LDAP Monitor with IPv4
+  bigip_monitor_ldap:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade LDAP Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade LDAP Monitor with IPv4 - Idempotent Check
+  bigip_monitor_ldap:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade LDAP Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update LDAP Monitor with IPv6
+  bigip_monitor_ldap:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade LDAP Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update LDAP Monitor with IPv6 - Idempotent Check
+  bigip_monitor_ldap:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade LDAP Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update LDAP Monitor with IP as *
+  bigip_monitor_ldap:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade LDAP Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update LDAP Monitor with IP as * - Idempotent Check
+  bigip_monitor_ldap:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade LDAP Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete LDAP Monitor
+  bigip_monitor_ldap:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete LDAP monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete LDAP Monitor - Idempotent Check
+  bigip_monitor_ldap:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete LDAP monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_ldap/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_ldap/tasks/main.yaml
@@ -593,3 +593,7 @@
 - import_tasks: issue-01353.yaml
   tags:
     - issue-01353
+
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163

--- a/test/integration/targets/bigip_monitor_mysql/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_mysql/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create MYSQL Monitor
+  bigip_monitor_mysql:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create MYSQL Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create MYSQL Monitor - Idempotent Check
+  bigip_monitor_mysql:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create MYSQL Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade MYSQL Monitor with IPv4
+  bigip_monitor_mysql:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade MYSQL Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade MYSQL Monitor with IPv4 - Idempotent Check
+  bigip_monitor_mysql:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade MYSQL Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update MYSQL Monitor with IPv6
+  bigip_monitor_mysql:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade MYSQL Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update MYSQL Monitor with IPv6 - Idempotent Check
+  bigip_monitor_mysql:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade MYSQL Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update MYSQL Monitor with IP as *
+  bigip_monitor_mysql:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade MYSQL Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update MYSQL Monitor with IP as * - Idempotent Check
+  bigip_monitor_mysql:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade MYSQL Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete MYSQL Monitor
+  bigip_monitor_mysql:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete MYSQL monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete MYSQL Monitor - Idempotent Check
+  bigip_monitor_mysql:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete MYSQL monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_mysql/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_mysql/tasks/main.yaml
@@ -154,3 +154,7 @@
           - result is success
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163

--- a/test/integration/targets/bigip_monitor_oracle/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_oracle/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create ORACLE Monitor
+  bigip_monitor_oracle:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create ORACLE Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create ORACLE Monitor - Idempotent Check
+  bigip_monitor_oracle:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create ORACLE Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade ORACLE Monitor with IPv4
+  bigip_monitor_oracle:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade ORACLE Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade ORACLE Monitor with IPv4 - Idempotent Check
+  bigip_monitor_oracle:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade ORACLE Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update ORACLE Monitor with IPv6
+  bigip_monitor_oracle:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade ORACLE Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update ORACLE Monitor with IPv6 - Idempotent Check
+  bigip_monitor_oracle:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade ORACLE Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update ORACLE Monitor with IP as *
+  bigip_monitor_oracle:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade ORACLE Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update ORACLE Monitor with IP as * - Idempotent Check
+  bigip_monitor_oracle:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade ORACLE Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete ORACLE Monitor
+  bigip_monitor_oracle:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete ORACLE monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete ORACLE Monitor - Idempotent Check
+  bigip_monitor_oracle:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete ORACLE monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_oracle/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_oracle/tasks/main.yaml
@@ -125,3 +125,7 @@
       - result is success
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163

--- a/test/integration/targets/bigip_monitor_smtp/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_smtp/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create SMTP Monitor
+  bigip_monitor_smtp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create SMTP Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create SMTP Monitor - Idempotent Check
+  bigip_monitor_smtp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create SMTP Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade SMTP Monitor with IPv4
+  bigip_monitor_smtp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade SMTP Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade SMTP Monitor with IPv4 - Idempotent Check
+  bigip_monitor_smtp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade SMTP Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update SMTP Monitor with IPv6
+  bigip_monitor_smtp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade SMTP Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update SMTP Monitor with IPv6 - Idempotent Check
+  bigip_monitor_smtp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade SMTP Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update SMTP Monitor with IP as *
+  bigip_monitor_smtp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade SMTP Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update SMTP Monitor with IP as * - Idempotent Check
+  bigip_monitor_smtp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade SMTP Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete SMTP Monitor
+  bigip_monitor_smtp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete SMTP monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete SMTP Monitor - Idempotent Check
+  bigip_monitor_smtp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete SMTP monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_smtp/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_smtp/tasks/main.yaml
@@ -184,3 +184,7 @@
     state: absent
 
 - import_tasks: teardown.yaml
+
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163

--- a/test/integration/targets/bigip_monitor_tcp/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_tcp/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create TCP Monitor
+  bigip_monitor_tcp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create TCP Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create TCP Monitor - Idempotent Check
+  bigip_monitor_tcp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create TCP Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade TCP Monitor with IPv4
+  bigip_monitor_tcp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade TCP Monitor with IPv4 - Idempotent Check
+  bigip_monitor_tcp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update TCP Monitor with IPv6
+  bigip_monitor_tcp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update TCP Monitor with IPv6 - Idempotent Check
+  bigip_monitor_tcp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update TCP Monitor with IP as *
+  bigip_monitor_tcp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update TCP Monitor with IP as * - Idempotent Check
+  bigip_monitor_tcp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete TCP Monitor
+  bigip_monitor_tcp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete TCP monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete TCP Monitor - Idempotent Check
+  bigip_monitor_tcp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete TCP monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_tcp/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_tcp/tasks/main.yaml
@@ -236,3 +236,7 @@
 - import_tasks: issue-recv-disable.yaml
   tags:
     - issue-recv-disable
+
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163

--- a/test/integration/targets/bigip_monitor_tcp_half_open/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_tcp_half_open/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create TCP Half Open Monitor
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create TCP Half Open Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create TCP Half Open Monitor - Idempotent Check
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create TCP Half Open Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade TCP Half Open Monitor with IPv4
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Half Open Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade TCP Half Open Monitor with IPv4 - Idempotent Check
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Half Open Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update TCP Half Open Monitor with IPv6
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Half Open Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update TCP Half Open Monitor with IPv6 - Idempotent Check
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Half Open Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update TCP Half Open Monitor with IP as *
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Half Open Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update TCP Half Open Monitor with IP as * - Idempotent Check
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade TCP Half Open Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete TCP Half Open Monitor
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete TCP Half Open monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete TCP Half Open Monitor - Idempotent Check
+  bigip_monitor_tcp_half_open:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete TCP Half Open monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_tcp_half_open/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_tcp_half_open/tasks/main.yaml
@@ -174,3 +174,7 @@
 - import_tasks: issue-01074.yaml
   tags:
     - issue-01074
+
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163

--- a/test/integration/targets/bigip_monitor_udp/tasks/issue-02163.yaml
+++ b/test/integration/targets/bigip_monitor_udp/tasks/issue-02163.yaml
@@ -1,0 +1,118 @@
+---
+- name: Issue 02163 - Create UDP Monitor
+  bigip_monitor_udp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create UDP Monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Create UDP Monitor - Idempotent Check
+  bigip_monitor_udp:
+    name: issue_02163
+  register: result
+
+- name: Issue 02163 - Assert Create UDP Monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Uptade UDP Monitor with IPv4
+  bigip_monitor_udp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade UDP Monitor with IPv4
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Uptade UDP Monitor with IPv4 - Idempotent Check
+  bigip_monitor_udp:
+    name: issue_02163
+    ip: '10.10.10.10'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade UDP Monitor with IPv4 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Update UDP Monitor with IPv6
+  bigip_monitor_udp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade UDP Monitor with IPv6
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update UDP Monitor with IPv6 - Idempotent Check
+  bigip_monitor_udp:
+    name: issue_02163
+    ip: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade UDP Monitor with IPv6 - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+  ignore_errors: true
+
+- name: Issue 02163 - Update UDP Monitor with IP as *
+  bigip_monitor_udp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+  register: result
+
+- name: Issue 02163 - Assert Uptade UDP Monitor with IP as *
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Update UDP Monitor with IP as * - Idempotent Check
+  bigip_monitor_udp:
+    name: issue_02163
+    ip: '*'
+    port: 4016
+    state: present
+  register: result
+
+- name: Issue 02163 - Assert Uptade UDP Monitor with IP as * - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+
+- name: Issue 02163 - Delete UDP Monitor
+  bigip_monitor_udp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete UDP monitor
+  assert:
+    that:
+      - result is changed
+
+- name: Issue 02163 - Delete UDP Monitor - Idempotent Check
+  bigip_monitor_udp:
+    name: issue_02163
+    state: absent
+  register: result
+
+- name: Issue 02163 - Assert Delete UDP monitor - Idempotent Check
+  assert:
+    that:
+      - result is not changed
+...

--- a/test/integration/targets/bigip_monitor_udp/tasks/main.yaml
+++ b/test/integration/targets/bigip_monitor_udp/tasks/main.yaml
@@ -236,3 +236,7 @@
 - import_tasks: issue-01074.yaml
   tags:
     - issue-01074
+
+- import_tasks: issue-02163.yaml
+  tags:
+    - issue-02163


### PR DESCRIPTION
This PR is a followup on PR #2206 which was about fixing how the ip was being extracted from destination value in http and https monitors, issue #2163 . This PR fixes it for all the monitors.