### PR TITLE
Added aliases to params related to availability requirement

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/add-parameter-aliases-bigip-pool.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/add-parameter-aliases-bigip-pool.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - bigip_pool - Added aliases for the parameters, monitor_type and quorum

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_pool.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_pool.py
@@ -66,6 +66,8 @@ options:
       - Both C(single) and C(and_list) are functionally identical, as BIG-IP
         considers all monitors as "a list".
     type: str
+    aliases:
+      - availability_requirements_type
     choices:
       - and_list
       - m_of_n
@@ -75,6 +77,8 @@ options:
       - Monitor quorum value when C(monitor_type) is C(m_of_n).
       - Quorum must be a value of 1 or greater when C(monitor_type) is C(m_of_n).
     type: int
+    aliases:
+      - availability_requirements_at_least
   monitors:
     description:
       - Monitor template name list. If the partition is not provided as part of
@@ -273,6 +277,22 @@ EXAMPLES = r'''
     partition: Common
     monitor_type: m_of_n
     quorum: 1
+    monitors:
+      - http
+      - tcp
+    provider:
+      server: lb.mydomain.com
+      user: admin
+      password: secret
+  delegate_to: localhost
+
+- name: Set multiple monitors (at least 2 must succeed)
+  bigip_pool:
+    state: present
+    name: my-pool
+    partition: Common
+    availability_requirements_type: m_of_n
+    availability_requirements_at_least: 2
     monitors:
       - http
       - tcp
@@ -1233,10 +1253,12 @@ class ArgumentSpec(object):
             monitor_type=dict(
                 choices=[
                     'and_list', 'm_of_n', 'single'
-                ]
+                ],
+                aliases=['availability_requirements_type']
             ),
             quorum=dict(
-                type='int'
+                type='int',
+                aliases=['availability_requirements_at_least']
             ),
             monitors=dict(
                 type='list',

--- a/test/integration/targets/bigip_pool/tasks/issue-02222.yaml
+++ b/test/integration/targets/bigip_pool/tasks/issue-02222.yaml
@@ -1,0 +1,63 @@
+---
+
+- name: Issue 02222 - Create a pool with availability requirements
+  bigip_pool:
+    state: present
+    name: issue_02222
+    partition: Common
+    availability_requirements_type: m_of_n
+    availability_requirements_at_least: 1
+    monitors:
+      - http
+      - tcp
+  register: result
+
+- name: Issue 02222 - Assert Create a pool with availability requirements
+  assert:
+    that:
+      - result is success
+      - result is changed
+
+- name: Issue 02222 - Create a pool with availability requirements - Idempotent Check
+  bigip_pool:
+    state: present
+    name: issue_02222
+    partition: Common
+    availability_requirements_type: m_of_n
+    availability_requirements_at_least: 1
+    monitors:
+      - http
+      - tcp
+  register: result
+
+- name: Issue 02222 - Assert Create a pool with availability requirements - Idempotent Check
+  assert:
+    that:
+      - result is success
+      - result is not changed
+
+- name: Issue 02222 - Remove pool
+  bigip_pool:
+    state: absent
+    name: issue_02222
+    partition: Common
+  register: result
+
+- name: Issue 02222 - Assert Remove pool
+  assert:
+    that:
+      - result is success
+      - result is changed
+
+- name: Issue 02222 - Remove pool -Idempotent Check
+  bigip_pool:
+    state: absent
+    name: issue_02222
+    partition: Common
+  register: result
+
+- name: Issue 02222 - Assert Remove pool - Idempotent Check
+  assert:
+    that:
+      - result is success
+      - result is not changed

--- a/test/integration/targets/bigip_pool/tasks/main.yaml
+++ b/test/integration/targets/bigip_pool/tasks/main.yaml
@@ -169,3 +169,6 @@
 
 - import_tasks: sr-1-8210113510.yaml
   tags: sr-1-8210113510
+
+- import_tasks: issue-02222.yaml
+  tags: issue-02222


### PR DESCRIPTION
This is to close #2222 . I have added aliases for `monitor_type` and `quorum` to make them look similar to availability requirements parameter in bigip_pool_member.

```
ansible-playbook ../f5-ansible/test/integration/bigip_pool.yaml -t "issue-02222"

PLAY [Metadata of bigip_pool] ****************************************************************************************************************************************************

PLAY [Test the bigip_pool module] ************************************************************************************************************************************************

TASK [bigip_pool : Issue 02222 - Create a pool with availability requirements] ***************************************************************************************************
changed: [bigip1]

TASK [bigip_pool : Issue 02222 - Assert Create a pool with availability requirements] ********************************************************************************************
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_pool : Issue 02222 - Create a pool with availability requirements - Idempotent Check] ********************************************************************************
ok: [bigip1]

TASK [bigip_pool : Issue 02222 - Assert Create a pool with availability requirements - Idempotent Check] *************************************************************************
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_pool : Issue 02222 - Remove pool] ************************************************************************************************************************************
changed: [bigip1]

TASK [bigip_pool : Issue 02222 - Assert Remove pool] *****************************************************************************************************************************
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_pool : Issue 02222 - Remove pool -Idempotent Check] ******************************************************************************************************************
ok: [bigip1]

TASK [bigip_pool : Issue 02222 - Assert Remove pool - Idempotent Check] **********************************************************************************************************
ok: [bigip1] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY RECAP ***********************************************************************************************************************************************************************
bigip1                     : ok=8    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```