### PR TITLE
feature: add asm config sync option

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/add_asm_sync_to_bigip_device_group.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/add_asm_sync_to_bigip_device_group.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - bigip_device_group - added a new parameter, asm_sync to support ASM policy synchronization

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_group.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_group.py
@@ -54,6 +54,7 @@ options:
       - When creating a new device group, this option will default to C(no).
     type: bool
     default: no
+    version_added: "1.21.0"
   save_on_auto_sync:
     description:
       - When performing an auto-sync, specifies whether the configuration

--- a/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_device_group.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_device_group.py
@@ -53,7 +53,8 @@ class TestParameters(unittest.TestCase):
             full_sync=False,
             description="my description",
             type="sync-failover",
-            auto_sync=True
+            auto_sync=True,
+            asm_sync=True
         )
 
         p = ModuleParameters(params=args)
@@ -62,6 +63,7 @@ class TestParameters(unittest.TestCase):
         assert p.description == "my description"
         assert p.type == "sync-failover"
         assert p.auto_sync is True
+        assert p.asm_sync is True
 
     def test_api_parameters(self):
         args = dict(
@@ -76,6 +78,7 @@ class TestParameters(unittest.TestCase):
 
         p = ApiParameters(params=args)
         assert p.auto_sync is True
+        assert p.asm_sync is False
         assert p.full_sync is False
         assert p.max_incremental_sync_size == 1024
         assert p.save_on_auto_sync is False

--- a/test/integration/targets/bigip_device_group/tasks/issue-02261.yaml
+++ b/test/integration/targets/bigip_device_group/tasks/issue-02261.yaml
@@ -1,0 +1,60 @@
+---
+
+- name: Set asm_sync on device group
+  bigip_device_group:
+    name: "{{ device_group_name }}"
+    asm_sync: yes
+  register: result
+  tags:
+    - bigip-cm-device-group-tests
+
+- name: Set asm_sync on device group
+  assert:
+    that:
+      - result is changed
+  tags:
+    - bigip-cm-device-group-tests
+
+- name: Set asm_sync on device group - Idempotent check
+  bigip_device_group:
+    name: "{{ device_group_name }}"
+    asm_sync: yes
+  register: result
+  tags:
+    - bigip-cm-device-group-tests
+
+- name: Set asm_sync on device group - Idempotent check
+  assert:
+    that:
+      - result is not changed
+  tags:
+    - bigip-cm-device-group-tests
+
+- name: Unset asm_sync on device group
+  bigip_device_group:
+    name: "{{ device_group_name }}"
+    asm_sync: no
+  register: result
+  tags:
+    - bigip-cm-device-group-tests
+
+- name: Unset asm_sync on device group
+  assert:
+    that:
+      - result is changed
+  tags:
+    - bigip-cm-device-group-tests
+
+- name: Unset asm_sync on device group - Idempotent and default value check
+  bigip_device_group:
+    name: "{{ device_group_name }}"
+  register: result
+  tags:
+    - bigip-cm-device-group-tests
+
+- name: Unset asm_sync on device group - Idempotent and default value check
+  assert:
+    that:
+      - result is not changed
+  tags:
+    - bigip-cm-device-group-tests


### PR DESCRIPTION
This PR adds the option to set `asm-sync` on a device-group, see #2261