### PR TITLE
Fixed permission and ownership for uploaded image file

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/sr-fix-image-upload-bug.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/sr-fix-image-upload-bug.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - bigip_software_image - fixed permission and ownership of the uploaded image file

--- a/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_software_image.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_software_image.py
@@ -77,6 +77,8 @@ class TestParameters(unittest.TestCase):
 class TestManager(unittest.TestCase):
     def setUp(self):
         self.spec = ArgumentSpec()
+        self.p1 = patch('ansible_collections.f5networks.f5_modules.plugins.modules.bigip_software_image.ModuleManager._set_mode_and_ownership')
+        self.p1.start()
         self.p2 = patch('ansible_collections.f5networks.f5_modules.plugins.modules.bigip_software_image.tmos_version')
         self.p3 = patch('ansible_collections.f5networks.f5_modules.plugins.modules.bigip_software_image.send_teem')
         self.m2 = self.p2.start()
@@ -85,6 +87,7 @@ class TestManager(unittest.TestCase):
         self.m3.return_value = True
 
     def tearDown(self):
+        self.p1.stop()
         self.p2.stop()
         self.p3.stop()
 

--- a/test/integration/targets/bigip_software_image/tasks/main.yaml
+++ b/test/integration/targets/bigip_software_image/tasks/main.yaml
@@ -64,3 +64,6 @@
 
 - import_tasks: issue-01379.yaml
   tags: issue-01379
+
+- import_tasks: sr-1-8581427611.yaml
+  tags: sr-1-8581427611

--- a/test/integration/targets/bigip_software_image/tasks/sr-1-8581427611.yaml
+++ b/test/integration/targets/bigip_software_image/tasks/sr-1-8581427611.yaml
@@ -1,0 +1,30 @@
+---
+
+- name: Upload the image
+  bigip_software_image:
+    image: "{{ initial_image }}"
+    state: present
+
+- name: Check file permission and ownership
+  uri:
+    url: https://{{ansible_host}}:{{bigip_port}}/mgmt/tm/util/bash
+    method: POST
+    validate_certs: no
+    user: "{{ bigip_username }}"
+    password: "{{ bigip_password }}"
+    force_basic_auth: yes
+    body_format: json
+    body:
+      command: "run"
+      utilCmdArgs: "-c 'stat -c \"%a %U %G\" /shared/images/BIGIP-16.1.1-0.0.16.iso'"
+  register: result
+
+- name: Assert file permission and ownership
+  assert:
+    that:
+      result.json.commandResult == "644 root root\n"
+
+- name: Remove the image from the bigip host
+  bigip_software_image:
+    image: "{{ initial_image }}"
+    state: absent


### PR DESCRIPTION
```
root@ubuntu:~/github/V1# ansible-playbook ../f5-ansible/test/integration/bigip_software_image.yaml -t "sr-1-8581427611" --step
[WARNING]: file /root/github/f5-ansible/test/integration/targets/bigip_software_image/tasks/teardown.yaml is empty and had no tasks to include

PLAY [Metadata of bigip_software_image] ******************************************************************************************************************************************

PLAY [Test the bigip_software_image module] **************************************************************************************************************************************
Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: y

Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: ***********************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************
ok: [bigip16]
Perform task: TASK: bigip_software_image : Upload the image (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_software_image : Upload the image (N)o/(y)es/(c)ontinue: ***********************************************************************************************

TASK [bigip_software_image : Upload the image] ***********************************************************************************************************************************
changed: [bigip16]
Perform task: TASK: bigip_software_image : Check file permission and ownership (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_software_image : Check file permission and ownership (N)o/(y)es/(c)ontinue: ****************************************************************************

TASK [bigip_software_image : Check file permission and ownership] ****************************************************************************************************************
ok: [bigip16]
Perform task: TASK: bigip_software_image : Assert file permission and ownership (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_software_image : Assert file permission and ownership (N)o/(y)es/(c)ontinue: ***************************************************************************

TASK [bigip_software_image : Assert file permission and ownership] ***************************************************************************************************************
ok: [bigip16] => {
    "changed": false
}

MSG:

All assertions passed
Perform task: TASK: bigip_software_image : Remove the image from the bigip host (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_software_image : Remove the image from the bigip host (N)o/(y)es/(c)ontinue: ***************************************************************************

TASK [bigip_software_image : Remove the image from the bigip host] ***************************************************************************************************************
changed: [bigip16]

PLAY RECAP ***********************************************************************************************************************************************************************
bigip16                    : ok=5    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```