### PR TITLE
Added option for license in bigip_device_info

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/add-license-option-bigip-device-info.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/add-license-option-bigip-device-info.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - bigip_device_info - added option for gathering info about device license.

--- a/test/integration/targets/bigip_device_info/tasks/issue-license-info.yaml
+++ b/test/integration/targets/bigip_device_info/tasks/issue-license-info.yaml
@@ -1,0 +1,27 @@
+---
+
+- name: Gather License info
+  bigip_device_info:
+    gather_subset:
+      - license
+  register: result
+
+- name: Assert Gather license info
+  assert:
+    that:
+      - result is success
+      - '"license" in result'
+
+- name: Gather all info except license
+  bigip_device_info:
+    gather_subset:
+      - all
+      - "!license"
+  register: result
+
+- name: Assert Gather license info
+  assert:
+    that:
+      - result is success
+      - '"license" not in result'
+

--- a/test/integration/targets/bigip_device_info/tasks/main.yaml
+++ b/test/integration/targets/bigip_device_info/tasks/main.yaml
@@ -541,3 +541,6 @@
 
 - import_tasks: issue-02209.yaml
   tags: issue-02209
+
+- import_tasks: issue-license-info.yaml
+  tags: issue-license


### PR DESCRIPTION
Added option to bigip_device_info to gather info for the license

```
ansible-playbook ../../f5-ansible/test/integration/bigip_device_info.yaml -t "issue-license"

PLAY [Metadata of bigip_device_info] *********************************************************************************************************************************************

PLAY [Test the bigip_device_info module] *****************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************
ok: [bigip16]

TASK [bigip_device_info : Gather License info] ***********************************************************************************************************************************
ok: [bigip16]

TASK [bigip_device_info : Assert Gather license info] ****************************************************************************************************************************
ok: [bigip16] => {
    "changed": false
}

MSG:

All assertions passed

TASK [bigip_device_info : Gather all info except license] ************************************************************************************************************************
ok: [bigip16]

TASK [bigip_device_info : Assert Gather license info] ****************************************************************************************************************************
ok: [bigip16] => {
    "changed": false
}

MSG:

All assertions passed

PLAY RECAP ***********************************************************************************************************************************************************************
bigip16                    : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```