### PR TITLE
Add fix for bug causing infinite loop in bigip_device_license

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-infinite-loop-device-license.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-infinite-loop-device-license.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - bigip_device_license - Add fix for a bug that caused infinite loop when the auth token expired

--- a/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
@@ -505,6 +505,8 @@ class F5BaseClient(object):
     def merge_provider_timeout_param(self, result, provider):
         if self.validate_params('timeout', provider):
             result['timeout'] = provider['timeout']
+        elif self.validate_params('F5_TIMEOUT', os.environ):
+            result['timeout'] = os.environ.get('F5_TIMEOUT')
         else:
             result['timeout'] = None
 

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_license.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_license.py
@@ -681,7 +681,9 @@ class ModuleManager(object):
                     nops += 1
                 else:
                     nops = 0
-            except Exception:
+            except Exception as ex:
+                if '"message":"X-F5-Auth-Token has expired."' in str(ex):
+                    raise F5ModuleError("X-F5-Auth-Token has expired.")
                 pass
             time.sleep(5)
 
@@ -707,7 +709,9 @@ class ModuleManager(object):
 
             if 'commandResult' in response:
                 return True
-        except Exception:
+        except Exception as ex:
+            if '"message":"X-F5-Auth-Token has expired."' in str(ex):
+                raise
             pass
         return False
 

--- a/test/integration/targets/bigip_device_license/tasks/issue-02275.yaml
+++ b/test/integration/targets/bigip_device_license/tasks/issue-02275.yaml
@@ -1,0 +1,18 @@
+- name: Set license key and server fact
+  set_fact:
+    license_key: "{{ lookup('env', 'LICENSE_KEY') }}"
+    license_server: "{{ lookup('env', 'LICENSE_SERVER') }}"
+
+- name: Add license to device, expect expired token error
+  bigip_device_license:
+    license_key: "{{ license_key }}"
+    accept_eula: yes
+    license_server: "{{ license_server }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert failure
+  assert:
+    that:
+      - result is not success
+      - result.msg == "X-F5-Auth-Token has expired."

--- a/test/integration/targets/bigip_device_license/tasks/main.yaml
+++ b/test/integration/targets/bigip_device_license/tasks/main.yaml
@@ -102,3 +102,7 @@
 - import_tasks: issue-02142.yaml
   tags:
     - issue-02142
+
+- import_tasks: issue-02275.yaml
+  tags:
+    - issue-02275


### PR DESCRIPTION
Fixes #2275

```
❯ ansible-playbook ../../f5-ansible/test/integration/bigip_device_license.yaml -t "issue-02275"
[WARNING]: Found both group and host with same name: f5os
[WARNING]: file /Users/r.upadhyay/Documents/github/f5_ansible/f5-ansible/test/integration/targets/bigip_device_license/tasks/teardown.yaml is empty and had no tasks to include

PLAY [Metadata of bigip_device_license] ******************************************************************************************************************************************

PLAY [Test the bigip_device_license module] **************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************
ok: [bigip16b]

TASK [bigip_device_license : Set license key and server fact] ********************************************************************************************************************
ok: [bigip16b]

TASK [bigip_device_license : Add license to device, expect expired token error] **************************************************************************************************
fatal: [bigip16b]: FAILED! => {
    "changed": false
}

MSG:

X-F5-Auth-Token has expired.
...ignoring

TASK [bigip_device_license : Assert failure] *************************************************************************************************************************************
ok: [bigip16b] => {
    "changed": false
}

MSG:

All assertions passed

PLAY RECAP ***********************************************************************************************************************************************************************
bigip16b                   : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1

```