### PR TITLE
Added timeout fix for long running commands in bigip_command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,12 @@ F5 BIG-IP Imperative Collection for Ansible
 
 |travis badge| |shippable badge|
 
+Important Warning
+-----------------
+
+Do not use https://f5cloudsolutions.herokuapp.com/ for accessing F5 slack channel. It is not owned/maintained/used by F5 anymore.
+You might be exposing yourself to security issues if you access this link thinking it to be the link to F5 slack channel. 
+
 Introduction
 ------------
 
@@ -171,10 +177,6 @@ See `License`_.
 .. |ansiblegethelp| raw:: html
 
    <a href="http://clouddocs.f5.com/products/orchestration/ansible/devel/usage/support.html" target="_blank">Get Help</a>
-
-.. |slacklink| raw:: html
-
-   <a href="https://f5cloudsolutions.herokuapp.com/" target="_blank">Slack channel</a>
 
 .. |changelog| raw:: html
 

--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/bigip-command-long-running-cmd-fix.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/bigip-command-long-running-cmd-fix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - bigip_command - Added note to give appropriate timeout value for long running commands

--- a/ansible_collections/f5networks/f5_modules/plugins/module_utils/bigip.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/module_utils/bigip.py
@@ -104,6 +104,7 @@ class F5RestClient(F5BaseClient):
         payload = {
             'timeout': token_timeout
         }
+        client_session.request.timeout = token_timeout
         response = client_session.patch(
             url,
             json=payload

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
@@ -94,6 +94,8 @@ notes:
   - When using the bigip_command module with the REST API, there are a number of places regex is used
     internally to escape characters such as quotation marks. If your TMSH command contains regex characters itself,
     such as datagroup wildcards C(*), then a large amount of escape characters may be needed.
+  - When issuing a long running command the user needs to give sufficiently big value for the timeout option in
+    provider block.
 extends_documentation_fragment: f5networks.f5_modules.f5_rest_cli
 author:
   - Tim Rupp (@caphrim007)
@@ -108,6 +110,16 @@ EXAMPLES = r'''
       server: lb.mydomain.com
       password: secret
       user: admin
+  delegate_to: localhost
+
+- name: sleep for 200 seconds
+  bigip_command:
+    commands: 'run /util bash -c "sleep 200"'
+    provider:
+      server: lb.mydomain.com
+      password: secret
+      user: admin
+      timeout: 210
   delegate_to: localhost
 
 - name: run show version and check to see if output contains BIG-IP

--- a/test/integration/targets/bigip_command/tasks/provider-rest/main.yaml
+++ b/test/integration/targets/bigip_command/tasks/provider-rest/main.yaml
@@ -148,3 +148,6 @@
 - import_tasks: issue-00843.yaml
   tags:
     - issue-00843
+
+- import_tasks: sleep.yaml
+  tags: sleep

--- a/test/integration/targets/bigip_command/tasks/provider-rest/sleep.yaml
+++ b/test/integration/targets/bigip_command/tasks/provider-rest/sleep.yaml
@@ -1,0 +1,21 @@
+---
+
+- name: sleep for 200 seconds
+  bigip_command:
+    commands: 'run /util bash -c "sleep 200"'
+    provider:
+      transport: rest
+      server: "{{ ansible_host }}"
+      user: "{{ bigip_username }}"
+      password: "{{ bigip_password }}"
+      validate_certs: no
+      server_port: "{{ bigip_port }}"
+      timeout: 250
+  delegate_to: localhost
+  register: result
+
+- name: Assert - command executed without error
+  assert:
+    that:
+      - result is success
+      - "'Error' not in result.stdout"

--- a/test/integration/targets/bigip_command/vars/issue-00843.yaml
+++ b/test/integration/targets/bigip_command/vars/issue-00843.yaml
@@ -1,6 +1,6 @@
 ---
-bigip_username: foo
+bigip_username: admin
 bigip_port: 443
-bigip_password: bar
+bigip_password: F5site02
 validate_certs: true
 no_f5_teem: false


### PR DESCRIPTION
```
ansible-playbook ../../f5-ansible/test/integration/bigip_command.yaml -t "provider" --start-at-task="sleep for 200 seconds" --step

PLAY [Metadata of bigip_command] *************************************************************************************************************************************************

PLAY [Test the bigip_command module - Environment] *******************************************************************************************************************************

PLAY [Test the bigip_command module - Provider-cli] ******************************************************************************************************************************

PLAY [Test the bigip_command module - Provider-rest] *****************************************************************************************************************************
Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: y

Perform task: TASK: Gathering Facts (N)o/(y)es/(c)ontinue: ***********************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************
ok: [bigip16b.com]
Perform task: TASK: bigip_command : sleep for 200 seconds (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_command : sleep for 200 seconds (N)o/(y)es/(c)ontinue: *************************************************************************************************

TASK [bigip_command : sleep for 200 seconds] *************************************************************************************************************************************
[WARNING]: Using "write" commands is not idempotent. You should use a module that is specifically made for that. If such a module does not exist, then please file a bug. The
command in question is "run /util bash -c "sleep 200"..."
ok: [bigip16b.com -> localhost]
Perform task: TASK: bigip_command : Assert - command executed without error (N)o/(y)es/(c)ontinue: y

Perform task: TASK: bigip_command : Assert - command executed without error (N)o/(y)es/(c)ontinue: *******************************************************************************

TASK [bigip_command : Assert - command executed without error] *******************************************************************************************************************
ok: [bigip16b.com] => {
    "changed": false
}

MSG:

All assertions passed

PLAY RECAP ***********************************************************************************************************************************************************************
bigip16b.com               : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```