### PR TITLE
Issue-2353 : Error Handling for Connection Error while executing command

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/error-handling-for-connection-error.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/error-handling-for-connection-error.yaml
@@ -1,4 +1,3 @@
-
 ---
 bugfixes:
   - bigip_device_certificate - error-handling for connection error while running exec command function to fetch certificate details

--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/error-handling-for-connection-error.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/error-handling-for-connection-error.yaml
@@ -1,0 +1,4 @@
+
+---
+bugfixes:
+  - bigip_device_certificate - error-handling for connection error while running exec command function to fetch certificate details

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_certificate.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_certificate.py
@@ -521,6 +521,8 @@ class ModuleManager(object):
         result = dict()
         command = 'openssl x509 -in /config/httpd/conf/ssl.crt/{0} -dates -issuer -noout'.format(self.want.cert_name)
         rc, out, err = exec_command(self.module, command)
+        if rc != 0:
+            raise F5ModuleError(err)
         if rc == 0:
             result['epoch'] = self._parse_cert_date(out)
         return ApiParameters(params=result)

--- a/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_device_certificate.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_device_certificate.py
@@ -206,5 +206,3 @@ class TestManager(unittest.TestCase):
             division='IT',
             common_name='foo.bar.local'
         )
-
-    

--- a/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_device_certificate.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_device_certificate.py
@@ -156,3 +156,55 @@ class TestManager(unittest.TestCase):
             common_name='foo.bar.local',
             email='admin@foo.bar.local'
         )
+
+    def test_create_new_cert_forcefully(self):
+        set_module_args(dict(
+            key_size=2048,
+            days_valid=60,
+            new_cert='yes',
+            force='yes',
+            issuer=dict(
+                country='US',
+                state='WA',
+                locality='Seattle',
+                organization='F5',
+                division='IT',
+                common_name='foo.bar.local',
+            ),
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin',
+                transport='cli',
+                server_port=22
+            )
+        ))
+
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            required_if=self.spec.required_if
+        )
+
+        mm = ModuleManager(module=module)
+        mm.expired = Mock(return_value=True)
+        mm.generate_cert_key = Mock(return_value=True)
+        mm.restart_daemon = Mock(return_value=True)
+        mm.configure_new_cert = Mock(return_value=True)
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['days_valid'] == 60
+        assert results['cert_name'] == 'server.crt'
+        assert results['key_name'] == 'server.key'
+        assert results['issuer'] == dict(
+            country='US',
+            state='WA',
+            locality='Seattle',
+            organization='F5',
+            division='IT',
+            common_name='foo.bar.local'
+        )
+
+    


### PR DESCRIPTION
#2353 
```
test_bigip_device_certificate.py ....                                                                                                              [100%]

=================================================================== 4 passed in 0.19s ====================================================================
Name                                                                                                                  Stmts   Miss  Cover
-----------------------------------------------------------------------------------------------------------------------------------------
/Users/p.ramani/F5/f5-ansible/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/config.py       326    258    21%
/Users/p.ramani/F5/f5-ansible/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/utils.py        410    342    17%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/module_utils/__init__.py                  0      0   100%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py                  351    258    26%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/module_utils/constants.py                15      0   100%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/__init__.py                       0      0   100%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_certificate.py     228     81    64%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/tests/__init__.py                                 0      0   100%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/tests/unit/__init__.py                            0      0   100%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/tests/unit/compat/__init__.py                     0      0   100%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/tests/unit/compat/mock.py                        53     46    13%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/tests/unit/compat/unittest.py                    10      4    60%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/tests/unit/modules/__init__.py                    0      0   100%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/__init__.py            0      0   100%
/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/tests/unit/modules/utils.py                      34     12    65%
__init__.py                                                                                                               0      0   100%
test_bigip_device_certificate.py                                                                                         78     12    85%
-----------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                                  1505   1013    33%
```