### PR TITLE
Change allowed_slots param type in bigip_vcmp_guest to match F5 expected type

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_vcmp_guest.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_vcmp_guest.py
@@ -158,7 +158,7 @@ options:
       - By default, this list includes every available slot in the cluster. This means
         the guest may be assigned to any slot by default.
     type: list
-    elements: str
+    elements: int
 notes:
   - This module can take a lot of time to deploy vCMP guests. This is an intrinsic
     limitation of the vCMP system, because it is booting real VMs on the BIG-IP
@@ -989,7 +989,7 @@ class ArgumentSpec(object):
             min_number_of_slots=dict(type='int'),
             allowed_slots=dict(
                 type='list',
-                elements='str',
+                elements='int',
             ),
             partition=dict(
                 default='Common',


### PR DESCRIPTION
The allowedSlots parameter in the F5 API is of type list of int. Currently the bigip_vcmp_guest module has this parameter as a list of str. When the module does a compare against the value from the F5 (list of int) and the variable supplied to the module (list of str) it always reports a diff. This results in Ansible reporting a change to the guest even when the configuration being pushed matches what is on the F5. Changing the parameter type in the module to a list of int to match what F5 expects correctly returns 'OK' when the allowed_slots variable matches what is configured on the F5.

This change was successfully tested on Ansible version 2.15.8 and F5 version 15.1.10.2 Build 0.44.2.

Closes #2394 