### PR TITLE
adding bigip_ucs module fix

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/bigip-ucs-restore-fix.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/bigip-ucs-restore-fix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - bigip_ucs - Fix for bigip_ucs module to restore UCS file on BIG-IP devices.

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
@@ -652,6 +652,11 @@ class V1Manager(BaseManager):
             elif 'remoteSender' in str(ex):
                 # catching some edge cases where API becomes unstable after installation
                 pass
+            elif 'Proxy Error' in str(ex):
+                # catching some edge cases where API becomes unstable after installation
+                pass
+            elif 'object has no attribute' in str(ex):
+                pass
             else:
                 raise F5ModuleError(str(ex))
         self.wait_for_rest_api_restart()

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
@@ -657,6 +657,8 @@ class V1Manager(BaseManager):
                 pass
             elif 'object has no attribute' in str(ex):
                 pass
+            elif 'Expecting value' in str(ex):
+                pass
             else:
                 raise F5ModuleError(str(ex))
         self.wait_for_rest_api_restart()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-ansible>=6.0.0,<7.0.0
+ansible>=8.5.0
 q
 invoke~=1.7.3
-
 Jinja2~=3.1.2
 packaging
 semver~=2.13.0
@@ -10,5 +9,5 @@ PyYAML~=6.0
 netaddr~=0.8.0
 packaging~=21.3
 ordereddict~=1.1
-cryptography~=38.0.3
+cryptography~=42.0.8
 objectpath~=0.6.1


### PR DESCRIPTION

Integration test results:
```
(.venv) ➜  f5-ansible git:(devel_ucs_fix) ✗ ansible-playbook -i ~/devsettings/inventory/bigip_ucs /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/bigip_ucs.yaml  -vvvv
ansible-playbook [core 2.17.2]
  config file = /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible.cfg
  configured module search path = ['/Users/r.chinthalapalli/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible
  ansible collection location = /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible
  executable location = /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/ansible-playbook
  python version = 3.12.3 (v3.12.3:f6650f9ad7, Apr  9 2024, 08:18:47) [Clang 13.0.0 (clang-1300.0.29.30)] (/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python)
  jinja version = 3.1.4
  libyaml = True
Using /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible.cfg as config file
setting up inventory plugins
Loading collection ansible.builtin from
Parsed /Users/r.chinthalapalli/devsettings/inventory/bigip_ucs inventory source with ini plugin
statically imported: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/setup.yaml
Loading collection f5networks.f5_modules from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules
statically imported: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/issue-2227.yaml
statically imported: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/teardown.yaml
Loading callback plugin default of type stdout, v2.0 from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible/plugins/callback/default.py
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: bigip_ucs.yaml ****************************************************************************************************************************************************************************************************************************
Positional arguments: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/bigip_ucs.yaml
verbosity: 4
connection: ssh
become_method: sudo
tags: ('all',)
inventory: ('/Users/r.chinthalapalli/devsettings/inventory/bigip_ucs',)
forks: 5
2 plays in /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/bigip_ucs.yaml

PLAY [Metadata of bigip_ucs] ************************************************************************************************************************************************************************************************************************

PLAY [Test the bigip_ucs module] ********************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/bigip_ucs.yaml:36
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278978.310621-27475-32937758591199 `" && echo ansible-tmp-1721278978.310621-27475-32937758591199="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278978.310621-27475-32937758591199 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible/modules/setup.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmpx15cg2kx TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278978.310621-27475-32937758591199/AnsiballZ_setup.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278978.310621-27475-32937758591199/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278978.310621-27475-32937758591199/AnsiballZ_setup.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278978.310621-27475-32937758591199/AnsiballZ_setup.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278978.310621-27475-32937758591199/ > /dev/null 2>&1 && sleep 0'
ok: [bigip]

TASK [bigip_ucs : Get temporary file for fetching UCS] **********************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/setup.yaml:3
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278980.8688982-27508-157878499713465 `" && echo ansible-tmp-1721278980.8688982-27508-157878499713465="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278980.8688982-27508-157878499713465 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible/modules/tempfile.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmpgh8pmazf TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278980.8688982-27508-157878499713465/AnsiballZ_tempfile.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278980.8688982-27508-157878499713465/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278980.8688982-27508-157878499713465/AnsiballZ_tempfile.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278980.8688982-27508-157878499713465/AnsiballZ_tempfile.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278980.8688982-27508-157878499713465/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "gid": 0,
    "group": "wheel",
    "invocation": {
        "module_args": {
            "path": null,
            "prefix": "ansible.",
            "state": "file",
            "suffix": "temp"
        }
    },
    "mode": "0600",
    "owner": "r.chinthalapalli",
    "path": "/tmp/ansible.qakhbm3htemp",
    "size": 0,
    "state": "file",
    "uid": 502
}

TASK [bigip_ucs : Save a UCS file locally for later usage] ******************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/setup.yaml:9
<10.171.120.85> Using network group action bigip for bigip_ucs_fetch
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278981.124201-27528-186618381716007 `" && echo ansible-tmp-1721278981.124201-27528-186618381716007="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278981.124201-27528-186618381716007 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs_fetch.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmpp5oi3brk TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278981.124201-27528-186618381716007/AnsiballZ_bigip_ucs_fetch.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278981.124201-27528-186618381716007/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278981.124201-27528-186618381716007/AnsiballZ_bigip_ucs_fetch.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278981.124201-27528-186618381716007/AnsiballZ_bigip_ucs_fetch.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721278981.124201-27528-186618381716007/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "checksum": "93a303e49969a28de89774cd3078ff8316890d12",
    "invocation": {
        "module_args": {
            "async_timeout": 150,
            "attributes": null,
            "backup": false,
            "create_on_missing": true,
            "dest": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs",
            "encryption_password": null,
            "fail_on_missing": false,
            "force": true,
            "group": null,
            "mode": null,
            "only_create_file": false,
            "owner": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "unsafe_writes": false
        }
    },
    "md5sum": "e756f56e17fbeeaee0e5c8716fca2777",
    "src": "mciwinj2.ucs"
}

TASK [bigip_ucs : Upload UCS file] ******************************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:5
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279022.300428-27554-134591956849080 `" && echo ansible-tmp-1721279022.300428-27554-134591956849080="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279022.300428-27554-134591956849080 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmpomxy3fsj TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279022.300428-27554-134591956849080/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279022.300428-27554-134591956849080/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279022.300428-27554-134591956849080/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279022.300428-27554-134591956849080/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279022.300428-27554-134591956849080/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "force": false,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "present",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs"
        }
    }
}

TASK [bigip_ucs : Assert Upload UCS file] ***********************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:10
ok: [bigip] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_ucs : Upload UCS file - Idempotent check] ***********************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:15
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279058.960438-27580-248858059667163 `" && echo ansible-tmp-1721279058.960438-27580-248858059667163="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279058.960438-27580-248858059667163 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmpzh3qrcnb TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279058.960438-27580-248858059667163/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279058.960438-27580-248858059667163/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279058.960438-27580-248858059667163/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279058.960438-27580-248858059667163/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279058.960438-27580-248858059667163/ > /dev/null 2>&1 && sleep 0'
ok: [bigip] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "force": false,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "present",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs"
        }
    }
}

TASK [bigip_ucs : Assert Upload UCS file - Idempotent check] ****************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:20
ok: [bigip] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_ucs : Force upload UCS file] ************************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:25
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279071.327768-27612-194495594952880 `" && echo ansible-tmp-1721279071.327768-27612-194495594952880="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279071.327768-27612-194495594952880 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmphtz077uf TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279071.327768-27612-194495594952880/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279071.327768-27612-194495594952880/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279071.327768-27612-194495594952880/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279071.327768-27612-194495594952880/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279071.327768-27612-194495594952880/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "force": true,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "present",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs"
        }
    }
}

TASK [bigip_ucs : Assert Force upload UCS file] *****************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:31
ok: [bigip] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_ucs : Install an uploaded UCS file] *****************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:36
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279102.6001542-27655-185291051780702 `" && echo ansible-tmp-1721279102.6001542-27655-185291051780702="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279102.6001542-27655-185291051780702 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmp3pnfjlzf TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279102.6001542-27655-185291051780702/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279102.6001542-27655-185291051780702/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279102.6001542-27655-185291051780702/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279102.6001542-27655-185291051780702/AnsiballZ_bigip_ucs.py && sleep 0'


<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279102.6001542-27655-185291051780702/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "force": false,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "installed",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs"
        }
    }
}

TASK [bigip_ucs : Assert Install an uploaded UCS file] **********************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:42
ok: [bigip] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_ucs : Install an uploaded UCS file again - expected not idempotent] *********************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:47
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279276.713139-27718-246358610194129 `" && echo ansible-tmp-1721279276.713139-27718-246358610194129="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279276.713139-27718-246358610194129 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmph241l948 TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279276.713139-27718-246358610194129/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279276.713139-27718-246358610194129/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279276.713139-27718-246358610194129/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279276.713139-27718-246358610194129/AnsiballZ_bigip_ucs.py && sleep 0'

<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279276.713139-27718-246358610194129/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "force": false,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "installed",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs"
        }
    }
}

TASK [bigip_ucs : Assert Install an uploaded UCS file again - expected not idempotent] **************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:53
ok: [bigip] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_ucs : Remove uploaded UCS file] *********************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:58
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279455.95277-28519-230062627512577 `" && echo ansible-tmp-1721279455.95277-28519-230062627512577="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279455.95277-28519-230062627512577 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmpbux_xasx TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279455.95277-28519-230062627512577/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279455.95277-28519-230062627512577/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279455.95277-28519-230062627512577/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279455.95277-28519-230062627512577/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279455.95277-28519-230062627512577/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "force": false,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "absent",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs"
        }
    }
}

TASK [bigip_ucs : Assert Remove uploaded UCS file] **************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:64
ok: [bigip] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_ucs : Remove uploaded UCS file - Idempotent check] **************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:69
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279474.86726-28558-45017133578345 `" && echo ansible-tmp-1721279474.86726-28558-45017133578345="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279474.86726-28558-45017133578345 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmphl3i6728 TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279474.86726-28558-45017133578345/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279474.86726-28558-45017133578345/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279474.86726-28558-45017133578345/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279474.86726-28558-45017133578345/AnsiballZ_bigip_ucs.py && sleep 0'

<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279474.86726-28558-45017133578345/ > /dev/null 2>&1 && sleep 0'
ok: [bigip] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "force": false,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "absent",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs"
        }
    }
}

TASK [bigip_ucs : Assert Remove uploaded UCS file - Idempotent check] *******************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:75
ok: [bigip] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_ucs : Install a UCS file, no initial upload] ********************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:80
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279486.3864949-28580-32999844816672 `" && echo ansible-tmp-1721279486.3864949-28580-32999844816672="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279486.3864949-28580-32999844816672 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmppqepe9p3 TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279486.3864949-28580-32999844816672/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279486.3864949-28580-32999844816672/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279486.3864949-28580-32999844816672/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279486.3864949-28580-32999844816672/AnsiballZ_bigip_ucs.py && sleep 0'

<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279486.3864949-28580-32999844816672/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "force": false,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "installed",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs"
        }
    }
}

TASK [bigip_ucs : Remove uploaded UCS file] *********************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/main.yaml:86
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279686.143937-29133-204049028458075 `" && echo ansible-tmp-1721279686.143937-29133-204049028458075="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279686.143937-29133-204049028458075 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmpimyl2_gi TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279686.143937-29133-204049028458075/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279686.143937-29133-204049028458075/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279686.143937-29133-204049028458075/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279686.143937-29133-204049028458075/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279686.143937-29133-204049028458075/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "force": false,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "absent",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs"
        }
    }
}

TASK [bigip_ucs : Get temporary file for fetching UCS] **********************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/issue-2227.yaml:3
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.569941-29178-163450472823732 `" && echo ansible-tmp-1721279710.569941-29178-163450472823732="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.569941-29178-163450472823732 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible/modules/file.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmp9frusof7 TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.569941-29178-163450472823732/AnsiballZ_file.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.569941-29178-163450472823732/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.569941-29178-163450472823732/AnsiballZ_file.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.569941-29178-163450472823732/AnsiballZ_file.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.569941-29178-163450472823732/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "dest": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs",
    "diff": {
        "after": {
            "atime": 1721279710.799127,
            "mtime": 1721279710.799127,
            "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs",
            "state": "touch"
        },
        "before": {
            "atime": 1721279710.7983396,
            "mtime": 1721279710.7983396,
            "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs",
            "state": "absent"
        }
    },
    "gid": 20,
    "group": "staff",
    "invocation": {
        "module_args": {
            "_diff_peek": null,
            "_original_basename": null,
            "access_time": null,
            "access_time_format": "%Y%m%d%H%M.%S",
            "attributes": null,
            "follow": true,
            "force": false,
            "group": null,
            "mode": 420,
            "modification_time": null,
            "modification_time_format": "%Y%m%d%H%M.%S",
            "owner": null,
            "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs",
            "recurse": false,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "state": "touch",
            "unsafe_writes": false
        }
    },
    "mode": "0644",
    "owner": "r.chinthalapalli",
    "size": 0,
    "state": "file",
    "uid": 502
}

TASK [bigip_ucs : Save a UCS file locally for later usage] ******************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/issue-2227.yaml:10
<10.171.120.85> Using network group action bigip for bigip_ucs_fetch
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.871777-29198-23904832661847 `" && echo ansible-tmp-1721279710.871777-29198-23904832661847="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.871777-29198-23904832661847 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs_fetch.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmpu5it6_pa TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.871777-29198-23904832661847/AnsiballZ_bigip_ucs_fetch.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.871777-29198-23904832661847/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.871777-29198-23904832661847/AnsiballZ_bigip_ucs_fetch.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.871777-29198-23904832661847/AnsiballZ_bigip_ucs_fetch.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279710.871777-29198-23904832661847/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "checksum": "dc71e3845f14ecc8b026bfa3065e671610ae67c8",
    "invocation": {
        "module_args": {
            "async_timeout": 150,
            "attributes": null,
            "backup": false,
            "create_on_missing": true,
            "dest": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs",
            "encryption_password": null,
            "fail_on_missing": false,
            "force": true,
            "group": null,
            "mode": null,
            "only_create_file": false,
            "owner": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "unsafe_writes": false
        }
    },
    "md5sum": "4d10defb797ac93db31a0fd438e31a5e",
    "src": "o2mgi8g0.ucs"
}

TASK [bigip_ucs : Upload UCS File] ******************************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/issue-2227.yaml:14
<10.171.120.85> Using network group action bigip for bigip_ucs
Loading collection ansible.netcommon from /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible_collections/ansible/netcommon
<10.171.120.85> connection transport is rest
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.171.120.85> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279756.666424-29222-230937492549708 `" && echo ansible-tmp-1721279756.666424-29222-230937492549708="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279756.666424-29222-230937492549708 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmpvbej10h0 TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279756.666424-29222-230937492549708/AnsiballZ_bigip_ucs.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279756.666424-29222-230937492549708/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279756.666424-29222-230937492549708/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279756.666424-29222-230937492549708/AnsiballZ_bigip_ucs.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279756.666424-29222-230937492549708/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "force": true,
            "include_chassis_level_config": null,
            "no_license": null,
            "no_platform_check": null,
            "passphrase": null,
            "provider": {
                "auth_provider": null,
                "no_f5_teem": false,
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "server": "10.171.120.85",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": false
            },
            "reset_trust": null,
            "state": "present",
            "ucs": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs"
        }
    }
}

TASK [bigip_ucs : Check file permission and ownership] **********************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/issue-2227.yaml:20
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279785.7027981-29242-88754569545660 `" && echo ansible-tmp-1721279785.7027981-29242-88754569545660="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279785.7027981-29242-88754569545660 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible/modules/uri.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmplmnw0gyu TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279785.7027981-29242-88754569545660/AnsiballZ_uri.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279785.7027981-29242-88754569545660/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279785.7027981-29242-88754569545660/AnsiballZ_uri.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279785.7027981-29242-88754569545660/AnsiballZ_uri.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279785.7027981-29242-88754569545660/ > /dev/null 2>&1 && sleep 0'
ok: [bigip] => {
    "allow": "",
    "cache_control": "no-store, no-cache, must-revalidate",
    "changed": false,
    "connection": "close",
    "content_length": "152",
    "content_security_policy": "default-src 'self'  'unsafe-inline' 'unsafe-eval' data: blob:; img-src 'self' data:  http://127.4.1.1 http://127.4.2.1",
    "content_type": "application/json;charset=utf-8",
    "cookies": {
        "BIGIPAuthCookie": "gjB4QPJWD66LCFhay17sTI4vFCTUah9A0ndilav4",
        "BIGIPAuthUsernameCookie": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
    },
    "cookies_string": "BIGIPAuthCookie=gjB4QPJWD66LCFhay17sTI4vFCTUah9A0ndilav4; BIGIPAuthUsernameCookie=********",
    "date": "Thu, 18 Jul 2024 05:16:26 GMT",
    "elapsed": 0,
    "expires": "-1",
    "invocation": {
        "module_args": {
            "attributes": null,
            "body": {
                "command": "run",
                "utilCmdArgs": "-c 'stat -c \"%a %U %G\" /var/local/ucs/basename.ucs'"
            },
            "body_format": "json",
            "ca_path": null,
            "ciphers": null,
            "client_cert": null,
            "client_key": null,
            "creates": null,
            "decompress": true,
            "dest": null,
            "follow_redirects": "safe",
            "force": false,
            "force_basic_auth": true,
            "group": null,
            "headers": {
                "Content-Type": "application/json"
            },
            "http_agent": "ansible-httpget",
            "method": "POST",
            "mode": null,
            "owner": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "remote_src": false,
            "removes": null,
            "return_content": false,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "status_code": [
                200
            ],
            "timeout": 30,
            "unix_socket": null,
            "unredirected_headers": [],
            "unsafe_writes": false,
            "url": "https://10.171.120.85:443/mgmt/tm/util/bash",
            "url_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "url_username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "use_gssapi": false,
            "use_netrc": true,
            "use_proxy": true,
            "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "validate_certs": false
        }
    },
    "json": {
        "command": "run",
        "commandResult": "644 root root\n",
        "kind": "tm:util:bash:runstate",
        "utilCmdArgs": "-c 'stat -c \"%a %U %G\" /var/local/ucs/basename.ucs'"
    },
    "msg": "OK (152 bytes)",
    "pragma": "no-cache",
    "redirected": false,
    "server": "Jetty(9.4.49.v20220914)",
    "set_cookie": "BIGIPAuthCookie=gjB4QPJWD66LCFhay17sTI4vFCTUah9A0ndilav4; path=/; Secure; HttpOnly; SameSite=Strict, BIGIPAuthUsernameCookie=********; path=/; Secure; HttpOnly; SameSite=Strict",
    "status": 200,
    "strict_transport_security": "max-age=16070400; includeSubDomains",
    "url": "https://10.171.120.85:443/mgmt/tm/util/bash",
    "x_content_type_options": "nosniff",
    "x_frame_options": "SAMEORIGIN",
    "x_xss_protection": "1; mode=block"
}

TASK [bigip_ucs : Assert file permission and ownership] *********************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/issue-2227.yaml:34
ok: [bigip] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [bigip_ucs : Remove temporary UCS file] ********************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/issue-2227.yaml:39
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.069715-29263-61587125628773 `" && echo ansible-tmp-1721279787.069715-29263-61587125628773="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.069715-29263-61587125628773 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible/modules/file.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmptqf1dxei TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.069715-29263-61587125628773/AnsiballZ_file.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.069715-29263-61587125628773/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.069715-29263-61587125628773/AnsiballZ_file.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.069715-29263-61587125628773/AnsiballZ_file.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.069715-29263-61587125628773/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "diff": {
        "after": {
            "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs",
            "state": "absent"
        },
        "before": {
            "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs",
            "state": "file"
        }
    },
    "invocation": {
        "module_args": {
            "_diff_peek": null,
            "_original_basename": null,
            "access_time": null,
            "access_time_format": "%Y%m%d%H%M.%S",
            "attributes": null,
            "follow": true,
            "force": false,
            "group": null,
            "mode": null,
            "modification_time": null,
            "modification_time_format": "%Y%m%d%H%M.%S",
            "owner": null,
            "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs",
            "recurse": false,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "state": "absent",
            "unsafe_writes": false
        }
    },
    "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/basename.ucs",
    "state": "absent"
}

TASK [bigip_ucs : Remove temporary UCS file] ********************************************************************************************************************************************************************************************************
task path: /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/tasks/teardown.yaml:3
<10.171.120.85> ESTABLISH LOCAL CONNECTION FOR USER: r.chinthalapalli
<10.171.120.85> EXEC /bin/sh -c 'echo ~r.chinthalapalli && sleep 0'
<10.171.120.85> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/r.chinthalapalli/.ansible/tmp `"&& mkdir "` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.274515-29283-173217742718855 `" && echo ansible-tmp-1721279787.274515-29283-173217742718855="` echo /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.274515-29283-173217742718855 `" ) && sleep 0'
Using module file /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/lib/python3.12/site-packages/ansible/modules/file.py
<10.171.120.85> PUT /Users/r.chinthalapalli/.ansible/tmp/ansible-local-27473h9xkb12e/tmp4xgcuac8 TO /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.274515-29283-173217742718855/AnsiballZ_file.py
<10.171.120.85> EXEC /bin/sh -c 'chmod u+x /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.274515-29283-173217742718855/ /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.274515-29283-173217742718855/AnsiballZ_file.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'F5_SERVER=10.171.120.85 F5_USER=admin F5_PASSWORD=admin F5_SERVER_PORT=443 F5_VALIDATE_CERTS=False F5_TEEM=True /Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/.venv/bin/python3 /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.274515-29283-173217742718855/AnsiballZ_file.py && sleep 0'
<10.171.120.85> EXEC /bin/sh -c 'rm -f -r /Users/r.chinthalapalli/.ansible/tmp/ansible-tmp-1721279787.274515-29283-173217742718855/ > /dev/null 2>&1 && sleep 0'
changed: [bigip] => {
    "changed": true,
    "diff": {
        "after": {
            "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs",
            "state": "absent"
        },
        "before": {
            "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs",
            "state": "file"
        }
    },
    "invocation": {
        "module_args": {
            "_diff_peek": null,
            "_original_basename": null,
            "access_time": null,
            "access_time_format": "%Y%m%d%H%M.%S",
            "attributes": null,
            "follow": true,
            "force": false,
            "group": null,
            "mode": null,
            "modification_time": null,
            "modification_time_format": "%Y%m%d%H%M.%S",
            "owner": null,
            "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs",
            "recurse": false,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "state": "absent",
            "unsafe_writes": false
        }
    },
    "path": "/Users/r.chinthalapalli/PycharmProjects/ansible/f5-ansible/test/integration/targets/bigip_ucs/files/ansible.qakhbm3htemp.ucs",
    "state": "absent"
}

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************
bigip                      : ok=26   changed=14   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```