### PR TITLE
Fixed Issue 2435 - bigip_profile_server_ssl fails to create server SSL profile if SSL key is passphrase protected 

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/issue_2435.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/issue_2435.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - bigip_profile_server_ssl - Fixed bug - create server SSL profile if SSL key is passphrase protected

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
@@ -269,6 +269,7 @@ class Parameters(AnsibleF5Parameters):
         'caFile',
         'authenticateName',
         'tmOptions',
+        'passphrase'
     ]
 
     returnables = [
@@ -440,6 +441,13 @@ class ModuleParameters(Parameters):
             return []
         return options
 
+    @property
+    def passphrase(self):
+        if self._values['passphrase'] is None:
+            return None
+        if self._values['passphrase'] in ['', 'none']:
+            return ''
+        return self._values['passphrase']
 
 class Changes(Parameters):
     def to_return(self):
@@ -699,6 +707,7 @@ class ModuleManager(object):
             self.client.provider['server'],
             self.client.provider['server_port']
         )
+        params['passphrase'] = self.want.passphrase
         resp = self.client.api.post(uri, json=params)
         try:
             response = resp.json()

--- a/test/integration/targets/bigip_profile_server_ssl/tasks/issue-02435.yaml
+++ b/test/integration/targets/bigip_profile_server_ssl/tasks/issue-02435.yaml
@@ -1,0 +1,20 @@
+---
+- name: Create a client SSL profile with a cert/key/chain setting
+  bigip_profile_client_ssl:
+    state: present
+    name: PRD.DEVTTY.LOCAL_CLIENTSSL
+    server_name: prd.devtty.local
+    cert_key_chain:
+      - cert: tc.crt
+        key: tc.key
+        passphrase: "F5site02"
+        true_names: true
+
+- name: Create a new server SSL profile with a cert/key/chain setting
+  bigip_profile_server_ssl:
+    state: present
+    name: PRD.DEVTTY.LOCAL_SERVERSSL
+    server_name: prd.devtty.local
+    certificate: tc.crt
+    key: tc.key
+    passphrase: "F5site02"

--- a/test/integration/targets/bigip_profile_server_ssl/tasks/main.yaml
+++ b/test/integration/targets/bigip_profile_server_ssl/tasks/main.yaml
@@ -1,5 +1,4 @@
 ---
-
 - import_tasks: setup.yaml
 
 - name: Create a base server SSL profile
@@ -72,11 +71,10 @@
       - result is not changed
       - result is success
 
-
 - name: Change OCSP - empty - Idempotent check
   bigip_profile_server_ssl:
     name: foo
-    ocsp_profile: ''
+    ocsp_profile: ""
   register: result
 
 - name: Assert Change OCSP - empty - Idempotent check
@@ -461,7 +459,7 @@
 - name: Set server_name - empty - Idempotent check
   bigip_profile_server_ssl:
     name: "{{ profile_2 }}"
-    server_name: ''
+    server_name: ""
   register: result
 
 - name: Assert Set server_name - empty - Idempotent check
@@ -494,3 +492,6 @@
 
 - import_tasks: issue-01609.yaml
   tags: issue-01609
+
+- import_tasks: issue-02435.yaml
+  tags: issue-02435


### PR DESCRIPTION
```
 ansible-playbook ../test/integration/bigip_profile_server_ssl.yaml -vvvv -t issue-02435
ansible-playbook [core 2.13.11]
  config file = /Users/p.ramani/F5/f5-ansible/playbooks/ansible.cfg
  configured module search path = ['/Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules']
  ansible python module location = /opt/homebrew/lib/python3.10/site-packages/ansible
  ansible collection location = /Users/p.ramani/F5/f5-ansible
  executable location = /opt/homebrew/bin/ansible-playbook
  python version = 3.10.7 (main, Sep 14 2022, 22:38:23) [Clang 14.0.0 (clang-1400.0.29.102)]
  jinja version = 3.1.2
  libyaml = True
Using /Users/p.ramani/F5/f5-ansible/playbooks/ansible.cfg as config file
setting up inventory plugins
host_list declined parsing /Users/p.ramani/F5/f5-ansible/playbooks/hosts as it did not pass its verify_file() method
script declined parsing /Users/p.ramani/F5/f5-ansible/playbooks/hosts as it did not pass its verify_file() method
auto declined parsing /Users/p.ramani/F5/f5-ansible/playbooks/hosts as it did not pass its verify_file() method
Parsed /Users/p.ramani/F5/f5-ansible/playbooks/hosts inventory source with ini plugin
statically imported: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/setup.yaml
Loading collection f5networks.f5_modules from /Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules
[WARNING]: Collection f5networks.f5_modules does not support Ansible version 2.13.11
statically imported: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/teardown.yaml
statically imported: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/issue-01433.yaml
statically imported: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/issue-01529.yaml
statically imported: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/issue-02040.yaml
statically imported: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/issue-01711.yaml
statically imported: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/issue-01609.yaml
statically imported: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/issue-02435.yaml
Loading callback plugin default of type stdout, v2.0 from /opt/homebrew/lib/python3.10/site-packages/ansible/plugins/callback/default.py
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: bigip_profile_server_ssl.yaml *****************************************************************************************************************************
Positional arguments: ../test/integration/bigip_profile_server_ssl.yaml
verbosity: 4
connection: smart
timeout: 10
become_method: sudo
tags: ('issue-02435',)
inventory: ('/Users/p.ramani/F5/f5-ansible/playbooks/hosts',)
forks: 5
2 plays in ../test/integration/bigip_profile_server_ssl.yaml

PLAY [Metadata of bigip_profile_server_ssl] *************************************************************************************************************************
META: ran handlers
META: ran handlers
META: ran handlers

PLAY [Test the bigip_profile_server_ssl module] *********************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************
task path: /Users/p.ramani/F5/f5-ansible/test/integration/bigip_profile_server_ssl.yaml:36
<10.145.71.31> ESTABLISH LOCAL CONNECTION FOR USER: p.ramani
<10.145.71.31> EXEC /bin/sh -c 'echo ~p.ramani && sleep 0'
<10.145.71.31> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/p.ramani/.ansible/tmp `"&& mkdir "` echo /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902365.554396-5075-20724279044950 `" && echo ansible-tmp-1733902365.554396-5075-20724279044950="` echo /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902365.554396-5075-20724279044950 `" ) && sleep 0'
<10.145.71.31> Attempting python interpreter discovery
<10.145.71.31> EXEC /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'python3.10'"'"'; command -v '"'"'python3.9'"'"'; command -v '"'"'python3.8'"'"'; command -v '"'"'python3.7'"'"'; command -v '"'"'python3.6'"'"'; command -v '"'"'python3.5'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'/usr/libexec/platform-python'"'"'; command -v '"'"'python2.7'"'"'; command -v '"'"'/usr/bin/python'"'"'; command -v '"'"'python'"'"'; echo ENDFOUND && sleep 0'
<10.145.71.31> Python interpreter discovery fallback (unsupported platform for extended discovery: darwin)
Using module file /opt/homebrew/lib/python3.10/site-packages/ansible/modules/setup.py
<10.145.71.31> PUT /Users/p.ramani/.ansible/tmp/ansible-local-5072j5yn9qac/tmpn0kyenq5 TO /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902365.554396-5075-20724279044950/AnsiballZ_setup.py
<10.145.71.31> EXEC /bin/sh -c 'chmod u+x /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902365.554396-5075-20724279044950/ /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902365.554396-5075-20724279044950/AnsiballZ_setup.py && sleep 0'
<10.145.71.31> EXEC /bin/sh -c 'F5_SERVER=10.145.71.31 F5_USER=admin F5_PASSWORD=F5site02 F5_SERVER_PORT=443 F5_VALIDATE_CERTS=no F5_TEEM='"'"''"'"' /opt/homebrew/bin/python3.10 /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902365.554396-5075-20724279044950/AnsiballZ_setup.py && sleep 0'
<10.145.71.31> EXEC /bin/sh -c 'rm -f -r /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902365.554396-5075-20724279044950/ > /dev/null 2>&1 && sleep 0'
[WARNING]: Platform darwin on host 10.145.71.31 is using the discovered Python interpreter at /opt/homebrew/bin/python3.10, but future installation of another
Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-core/2.13/reference_appendices/interpreter_discovery.html for more
information.
ok: [10.145.71.31]
META: ran handlers

TASK [bigip_profile_server_ssl : Create a client SSL profile with a cert/key/chain setting] *************************************************************************
task path: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/issue-02435.yaml:2
<10.145.71.31> Using network group action bigip for bigip_profile_client_ssl
Loading collection ansible.netcommon from /Users/p.ramani/F5/f5-ansible/ansible_collections/ansible/netcommon
<10.145.71.31> connection transport is rest
<10.145.71.31> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.145.71.31> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.145.71.31> ESTABLISH LOCAL CONNECTION FOR USER: p.ramani
<10.145.71.31> EXEC /bin/sh -c 'echo ~p.ramani && sleep 0'
<10.145.71.31> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/p.ramani/.ansible/tmp `"&& mkdir "` echo /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902367.595231-5127-262573901083917 `" && echo ansible-tmp-1733902367.595231-5127-262573901083917="` echo /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902367.595231-5127-262573901083917 `" ) && sleep 0'
Using module file /Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_client_ssl.py
<10.145.71.31> PUT /Users/p.ramani/.ansible/tmp/ansible-local-5072j5yn9qac/tmpic4gveh_ TO /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902367.595231-5127-262573901083917/AnsiballZ_bigip_profile_client_ssl.py
<10.145.71.31> EXEC /bin/sh -c 'chmod u+x /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902367.595231-5127-262573901083917/ /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902367.595231-5127-262573901083917/AnsiballZ_bigip_profile_client_ssl.py && sleep 0'
<10.145.71.31> EXEC /bin/sh -c 'F5_SERVER=10.145.71.31 F5_USER=admin F5_PASSWORD=F5site02 F5_SERVER_PORT=443 F5_VALIDATE_CERTS=no F5_TEEM='"'"''"'"' /opt/homebrew/bin/python3.10 /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902367.595231-5127-262573901083917/AnsiballZ_bigip_profile_client_ssl.py && sleep 0'
<10.145.71.31> EXEC /bin/sh -c 'rm -f -r /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902367.595231-5127-262573901083917/ > /dev/null 2>&1 && sleep 0'
changed: [10.145.71.31] => {
    "cert_key_chain": [
        {
            "cert": "/Common/********",
            "chain": "none",
            "key": "/Common/********",
            "name": "tc",
            "passphrase": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
        }
    ],
    "changed": true,
    "invocation": {
        "module_args": {
            "advertised_cert_authority": null,
            "allow_expired_crl": null,
            "allow_non_ssl": null,
            "cache_size": null,
            "cache_timeout": null,
            "cert_auth_depth": null,
            "cert_key_chain": [
                {
                    "cert": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                    "chain": null,
                    "key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                    "passphrase": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                    "true_names": true
                }
            ],
            "cipher_group": null,
            "ciphers": null,
            "client_auth_crl": null,
            "client_auth_frequency": null,
            "client_certificate": null,
            "name": "PRD.DEVTTY.LOCAL_CLIENTSSL",
            "options": null,
            "parent": null,
            "partition": "Common",
            "provider": {
                "auth_provider": null,
                "no_f5_teem": null,
                "password": null,
                "server": "10.145.71.31",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "admin",
                "validate_certs": false
            },
            "renegotiation": null,
            "retain_certificate": null,
            "secure_renegotiation": null,
            "server_name": "prd.devtty.local",
            "sni_default": null,
            "sni_require": null,
            "state": "present",
            "strict_resume": null,
            "trusted_cert_authority": null
        }
    },
    "server_name": "prd.devtty.local"
}

TASK [bigip_profile_server_ssl : Create a new server SSL profile with a cert/key/chain setting] *********************************************************************
task path: /Users/p.ramani/F5/f5-ansible/test/integration/targets/bigip_profile_server_ssl/tasks/issue-02435.yaml:13
<10.145.71.31> Using network group action bigip for bigip_profile_server_ssl
Loading collection ansible.netcommon from /Users/p.ramani/F5/f5-ansible/ansible_collections/ansible/netcommon
<10.145.71.31> connection transport is rest
<10.145.71.31> ANSIBLE_NETWORK_IMPORT_MODULES: disabled
<10.145.71.31> ANSIBLE_NETWORK_IMPORT_MODULES: module execution time may be extended
<10.145.71.31> ESTABLISH LOCAL CONNECTION FOR USER: p.ramani
<10.145.71.31> EXEC /bin/sh -c 'echo ~p.ramani && sleep 0'
<10.145.71.31> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/p.ramani/.ansible/tmp `"&& mkdir "` echo /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902375.355478-5159-208937859447100 `" && echo ansible-tmp-1733902375.355478-5159-208937859447100="` echo /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902375.355478-5159-208937859447100 `" ) && sleep 0'
Using module file /Users/p.ramani/F5/f5-ansible/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
<10.145.71.31> PUT /Users/p.ramani/.ansible/tmp/ansible-local-5072j5yn9qac/tmpfd8367eu TO /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902375.355478-5159-208937859447100/AnsiballZ_bigip_profile_server_ssl.py
<10.145.71.31> EXEC /bin/sh -c 'chmod u+x /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902375.355478-5159-208937859447100/ /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902375.355478-5159-208937859447100/AnsiballZ_bigip_profile_server_ssl.py && sleep 0'
<10.145.71.31> EXEC /bin/sh -c 'F5_SERVER=10.145.71.31 F5_USER=admin F5_PASSWORD=F5site02 F5_SERVER_PORT=443 F5_VALIDATE_CERTS=no F5_TEEM='"'"''"'"' /opt/homebrew/bin/python3.10 /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902375.355478-5159-208937859447100/AnsiballZ_bigip_profile_server_ssl.py && sleep 0'
<10.145.71.31> EXEC /bin/sh -c 'rm -f -r /Users/p.ramani/.ansible/tmp/ansible-tmp-1733902375.355478-5159-208937859447100/ > /dev/null 2>&1 && sleep 0'
ok: [10.145.71.31] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "authenticate_name": null,
            "ca_file": null,
            "certificate": "tc.crt",
            "chain": null,
            "cipher_group": null,
            "ciphers": null,
            "key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "name": "PRD.DEVTTY.LOCAL_SERVERSSL",
            "ocsp_profile": null,
            "options": null,
            "parent": "/Common/serverssl",
            "partition": "Common",
            "passphrase": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "provider": {
                "auth_provider": null,
                "no_f5_teem": null,
                "password": null,
                "server": "10.145.71.31",
                "server_port": 443,
                "timeout": null,
                "transport": "rest",
                "user": "admin",
                "validate_certs": false
            },
            "renegotiation": null,
            "secure_renegotiation": null,
            "server_certificate": null,
            "server_name": "prd.devtty.local",
            "sni_default": null,
            "sni_require": null,
            "state": "present",
            "update_password": "always"
        }
    }
}
META: role_complete for 10.145.71.31
META: ran handlers
META: ran handlers

PLAY RECAP **********************************************************************************************************************************************************
10.145.71.31               : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```