### PR TITLE
Issue with parent argument accepting None but expecting a string in bigip_profile_server_ssl module

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/2458-profile-server-ssl.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/2458-profile-server-ssl.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - bigip_profile_server_ssl to support parent's [None, "", "None"] profiles

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
@@ -24,7 +24,7 @@ options:
     description:
       - The parent template of this monitor template. Once this value has
         been set, it cannot be changed.
-    type: str
+    type: raw
     default: /Common/serverssl
   ciphers:
     description:
@@ -383,10 +383,11 @@ class ModuleParameters(Parameters):
 
     @property
     def parent(self):
-        if self._values['parent'] is None:
+        parent = self._values.get("parent")
+        if parent in [None, "", "None"]:
             return None
-        if self._values['parent'] == 'serverssl':
-            return '/Common/serverssl'
+        if parent == "serverssl":
+            return "/Common/serverssl"
         result = fq_name(self.partition, self._values['parent'])
         return result
 
@@ -785,7 +786,7 @@ class ArgumentSpec(object):
             chain=dict(),
             key=dict(no_log=True),
             passphrase=dict(no_log=True),
-            parent=dict(default='/Common/serverssl'),
+            parent=dict(type='raw', default='/Common/serverssl'),
             ciphers=dict(),
             cipher_group=dict(),
             authenticate_name=dict(),

--- a/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_profile_server_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_profile_server_ssl.py
@@ -61,6 +61,54 @@ class TestParameters(unittest.TestCase):
         assert p.secure_renegotiation == 'require'
         assert p.passphrase == 'F5site02'
 
+    def test_module_parameters_parent_none(self):
+        args = dict(
+            name='foo',
+            server_name='foo.bar.com',
+            secure_renegotiation='require',
+            passphrase="F5site02",
+            parent=None
+        )
+
+        p = ModuleParameters(params=args)
+        assert p.name == 'foo'
+        assert p.server_name == 'foo.bar.com'
+        assert p.secure_renegotiation == 'require'
+        assert p.passphrase == 'F5site02'
+        assert p.parent is None
+
+    def test_module_parameters_parent_none_str(self):
+        args = dict(
+            name='foo',
+            server_name='foo.bar.com',
+            secure_renegotiation='require',
+            passphrase="F5site02",
+            parent="None"
+        )
+
+        p = ModuleParameters(params=args)
+        assert p.name == 'foo'
+        assert p.server_name == 'foo.bar.com'
+        assert p.secure_renegotiation == 'require'
+        assert p.passphrase == 'F5site02'
+        assert p.parent == "None"
+
+    def test_module_parameters_parent_none_str(self):
+        args = dict(
+            name='foo',
+            server_name='foo.bar.com',
+            secure_renegotiation='require',
+            passphrase="F5site02",
+            parent="foo"
+        )
+
+        p = ModuleParameters(params=args)
+        assert p.name == 'foo'
+        assert p.server_name == 'foo.bar.com'
+        assert p.secure_renegotiation == 'require'
+        assert p.passphrase == 'F5site02'
+        assert p.parent == '/Common/foo'
+
     def test_api_parameters(self):
         args = load_fixture('load_ltm_profile_serverssl_1.json')
         p = ApiParameters(params=args)

--- a/test/integration/targets/bigip_profile_server_ssl/tasks/issue-2458.yaml
+++ b/test/integration/targets/bigip_profile_server_ssl/tasks/issue-2458.yaml
@@ -1,0 +1,105 @@
+
+---
+
+- name: Test - Omitted parent
+  bigip_profile_server_ssl:
+    name: ssl_omitted
+  register: result
+
+- name: Assert - parent omitted
+  assert:
+    that: [ "result is not changed" ]
+
+---
+
+# 2. parent = null
+- name: Test - parent: null
+  bigip_profile_server_ssl:
+    name: ssl_null
+    parent: null
+  register: result
+
+- name: Assert - parent: null
+  assert:
+    that: [ "result is not changed" ]
+
+---
+
+# 3. parent = ""
+- name: Test - parent: ""
+  bigip_profile_server_ssl:
+    name: ssl_empty
+    parent: ""
+  register: result
+
+- name: Assert - parent: ""
+  assert:
+    that: [ "result is not changed" ]
+
+---
+
+# 4. parent = "None" (string)
+- name: Test - parent: "None"
+  bigip_profile_server_ssl:
+    name: ssl_string_none
+    parent: "None"
+  register: result
+
+- name: Assert - parent: "None"
+  assert:
+    that: [ "result is not changed" ]
+
+---
+
+# 5. parent = "serverssl"
+- name: Test - parent: "serverssl"
+  bigip_profile_server_ssl:
+    name: ssl_short
+    parent: "serverssl"
+  register: result
+
+- name: Assert - parent: "serverssl"
+  assert:
+    that: [ "result is not changed" ]
+
+---
+
+# 6. parent = "/Common/custom"
+- name: Test - parent: "/Common/custom"
+  bigip_profile_server_ssl:
+    name: ssl_full
+    parent: "/Common/custom"
+  register: result
+
+- name: Assert - parent: "/Common/custom"
+  assert:
+    that: [ "result is not changed" ]
+
+---
+
+# 7. parent = "profileABC"
+- name: Test - parent: "profileABC"
+  bigip_profile_server_ssl:
+    name: ssl_other
+    parent: "profileABC"
+  register: result
+
+- name: Assert - parent: "profileABC"
+  assert:
+    that: [ "result is not changed" ]
+
+---
+
+# Cleanup
+- name: Cleanup server SSL test profiles
+  bigip_profile_server_ssl:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - ssl_omitted
+    - ssl_null
+    - ssl_empty
+    - ssl_string_none
+    - ssl_short
+    - ssl_full
+    - ssl_other


### PR DESCRIPTION
Issue: Issue with parent argument accepting None but expecting a string in bigip_profile_server_ssl module

Fix: Added support for parent profile None and null

Resolves: #2459 

Ran Sanity and unit test cases

inv test.f5-sanity
inv test.style
inv test.unit
inv test.ansible-test -r -p 3.13