### PR TITLE
Properly detect all HTTP errors.

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/lookup/bigiq_license.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/lookup/bigiq_license.py
@@ -85,7 +85,7 @@ class LookupModule(LookupBase):
             response = resp.json()
         except ValueError as ex:
             raise AnsibleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise AnsibleError(response['message'])
             else:
@@ -109,7 +109,7 @@ class LookupModule(LookupBase):
             response = resp.json()
         except ValueError as ex:
             raise AnsibleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise AnsibleError(response['message'])
             else:
@@ -141,7 +141,7 @@ class LookupModule(LookupBase):
             except ValueError as ex:
                 raise AnsibleError(str(ex))
 
-            if 'code' in response and response['code'] == 400:
+            if 'code' in response and response['code'] >= 400:
                 if 'message' in response:
                     raise AnsibleError(response['message'])
                 else:

--- a/ansible_collections/f5networks/f5_modules/plugins/module_utils/bigiq.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/module_utils/bigiq.py
@@ -127,7 +127,7 @@ class F5RestClient(F5BaseClient):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_command.py
@@ -659,7 +659,7 @@ class V2Manager(BaseManager):
             except ValueError as ex:
                 raise F5ModuleError(str(ex))
 
-            if 'code' in response and response['code'] == 400:
+            if 'code' in response and response['code'] >= 400:
                 if 'message' in response:
                     raise F5ModuleError(response['message'])
                 else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_auth.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_auth.py
@@ -501,7 +501,7 @@ class BaseManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_device_info.py
@@ -16566,7 +16566,7 @@ class TrunksFactManager(BaseManager):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_partition.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_partition.py
@@ -345,7 +345,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -362,7 +362,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -427,7 +427,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -446,7 +446,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_password_policy.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_password_policy.py
@@ -362,7 +362,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -379,7 +379,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_policy.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_policy.py
@@ -416,7 +416,7 @@ class BaseManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -667,7 +667,7 @@ class SimpleManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -692,7 +692,7 @@ class SimpleManager(BaseManager):
             except ValueError as ex:
                 raise F5ModuleError(str(ex))
 
-            if 'code' in response and response['code'] == 400:
+            if 'code' in response and response['code'] >= 400:
                 if 'message' in response:
                     raise F5ModuleError(response['message'])
                 else:
@@ -903,7 +903,7 @@ class ComplexManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -949,7 +949,7 @@ class ComplexManager(BaseManager):
             except ValueError as ex:
                 raise F5ModuleError(str(ex))
 
-            if 'code' in response and response['code'] == 400:
+            if 'code' in response and response['code'] >= 400:
                 if 'message' in response:
                     raise F5ModuleError(response['message'])
                 else:
@@ -977,7 +977,7 @@ class ComplexManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_pool.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_pool.py
@@ -1255,7 +1255,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1297,7 +1297,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1352,7 +1352,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1384,7 +1384,7 @@ class ModuleManager(object):
                 except ValueError as ex:
                     raise F5ModuleError(str(ex))
 
-                if 'code' in response and response['code'] == 400:
+                if 'code' in response and response['code'] >= 400:
                     if 'message' in response:
                         raise F5ModuleError(response['message'])
                     else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_analytics.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_analytics.py
@@ -691,7 +691,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_client_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_client_ssl.py
@@ -1125,7 +1125,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_dns.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_dns.py
@@ -689,7 +689,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_ftp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_ftp.py
@@ -568,7 +568,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -597,7 +597,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_http.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_http.py
@@ -1669,7 +1669,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_http2.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_http2.py
@@ -605,7 +605,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_http_compression.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_http_compression.py
@@ -485,7 +485,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_oneconnect.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_oneconnect.py
@@ -554,7 +554,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_persistence_cookie.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_persistence_cookie.py
@@ -872,7 +872,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_persistence_src_addr.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_persistence_src_addr.py
@@ -574,7 +574,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_persistence_universal.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_persistence_universal.py
@@ -544,7 +544,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
@@ -769,7 +769,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_sip.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_sip.py
@@ -696,7 +696,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -725,7 +725,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_udp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_udp.py
@@ -413,7 +413,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_provision.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_provision.py
@@ -741,7 +741,7 @@ class ModuleManager(object):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -759,7 +759,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_provision_async.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_provision_async.py
@@ -982,7 +982,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_remote_role.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_remote_role.py
@@ -462,7 +462,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 if 'Once configured [All] partition, remote user group cannot' in response['message']:
                     raise F5ModuleError(
@@ -486,7 +486,7 @@ class ModuleManager(object):
         response = self.client.api.delete(uri)
         if response.status == 200:
             return True
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -504,7 +504,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_remote_syslog.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_remote_syslog.py
@@ -409,7 +409,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_remote_user.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_remote_user.py
@@ -301,7 +301,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -318,7 +318,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_routedomain.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_routedomain.py
@@ -298,7 +298,7 @@ class ApiParameters(Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_selfip.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_selfip.py
@@ -827,7 +827,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -855,7 +855,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -874,7 +874,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_service_policy.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_service_policy.py
@@ -363,7 +363,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -392,7 +392,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_smtp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_smtp.py
@@ -481,7 +481,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -509,7 +509,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snat_pool.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snat_pool.py
@@ -441,7 +441,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -471,7 +471,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snat_translation.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snat_translation.py
@@ -678,7 +678,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -707,7 +707,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snmp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snmp.py
@@ -346,7 +346,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -365,7 +365,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snmp_community.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snmp_community.py
@@ -697,7 +697,7 @@ class V1Manager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -725,7 +725,7 @@ class V1Manager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -819,7 +819,7 @@ class V2Manager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -848,7 +848,7 @@ class V2Manager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snmp_trap.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_snmp_trap.py
@@ -551,7 +551,7 @@ class BaseManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -631,7 +631,7 @@ class V3Manager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -681,7 +681,7 @@ class V2Manager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -742,7 +742,7 @@ class V1Manager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_software_install.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_software_install.py
@@ -154,7 +154,7 @@ class ApiParameters(Parameters):
         except ValueError:
             return []
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 return []
             else:
@@ -181,7 +181,7 @@ class ApiParameters(Parameters):
         except ValueError:
             return []
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 return []
             else:
@@ -201,7 +201,7 @@ class ApiParameters(Parameters):
         except ValueError:
             return []
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 return []
             else:
@@ -666,7 +666,7 @@ class ModuleManager(object):
             # At times during reboot BIG-IP will reset or timeout connections so we catch and pass this here.
             return None
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_software_update.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_software_update.py
@@ -265,7 +265,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -284,7 +284,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ssl_ocsp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ssl_ocsp.py
@@ -670,7 +670,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -704,7 +704,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_static_route.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_static_route.py
@@ -582,7 +582,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -600,7 +600,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_sys_daemon_log_tmm.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_sys_daemon_log_tmm.py
@@ -398,7 +398,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -415,7 +415,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_sys_db.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_sys_db.py
@@ -309,7 +309,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -332,7 +332,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -355,7 +355,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_sys_global.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_sys_global.py
@@ -446,7 +446,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -465,7 +465,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_timer_policy.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_timer_policy.py
@@ -530,7 +530,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -559,7 +559,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_traffic_selector.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_traffic_selector.py
@@ -424,7 +424,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -457,7 +457,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_trunk.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_trunk.py
@@ -524,7 +524,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -552,7 +552,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_tunnel.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_tunnel.py
@@ -517,7 +517,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -537,7 +537,7 @@ class ModuleManager(object):
         response = self.client.api.delete(uri)
         if response.status == 200:
             return True
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -555,7 +555,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs.py
@@ -559,7 +559,7 @@ class V1Manager(BaseManager):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -688,7 +688,7 @@ class V2Manager(V1Manager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs_fetch.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_ucs_fetch.py
@@ -652,7 +652,7 @@ class V2Manager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_user.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_user.py
@@ -684,7 +684,7 @@ class UnpartitionedManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -713,7 +713,7 @@ class UnpartitionedManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -814,7 +814,7 @@ class PartitionedManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_vcmp_guest.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_vcmp_guest.py
@@ -668,7 +668,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -697,7 +697,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -720,7 +720,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -798,7 +798,7 @@ class ModuleManager(object):
         if resp.status == 404 or 'code' in response and response['code'] == 404:
             return True
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -818,7 +818,7 @@ class ModuleManager(object):
             response = resp.json()
         except ValueError:
             return False
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -847,7 +847,7 @@ class ModuleManager(object):
             response = resp.json()
         except ValueError:
             return False
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -884,7 +884,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -916,7 +916,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -948,7 +948,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_address.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_address.py
@@ -764,7 +764,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -784,7 +784,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
@@ -1275,7 +1275,7 @@ class Parameters(AnsibleF5Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1294,7 +1294,7 @@ class Parameters(AnsibleF5Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1316,7 +1316,7 @@ class Parameters(AnsibleF5Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1335,7 +1335,7 @@ class Parameters(AnsibleF5Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1354,7 +1354,7 @@ class Parameters(AnsibleF5Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1373,7 +1373,7 @@ class Parameters(AnsibleF5Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1392,7 +1392,7 @@ class Parameters(AnsibleF5Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -3062,7 +3062,7 @@ class VirtualServerValidator(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -3081,7 +3081,7 @@ class VirtualServerValidator(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -3100,7 +3100,7 @@ class VirtualServerValidator(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -3120,7 +3120,7 @@ class VirtualServerValidator(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -3139,7 +3139,7 @@ class VirtualServerValidator(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_fasthttp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_fasthttp.py
@@ -268,7 +268,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No default HTTP LB template was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -298,7 +298,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(str(ex))
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -323,7 +323,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(str(ex))
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -646,7 +646,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -674,7 +674,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_fastl4_tcp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_fastl4_tcp.py
@@ -267,7 +267,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No default HTTP LB template was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -299,7 +299,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "The specified service_environment '{0}' was found.".format(self.service_environment)
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -594,7 +594,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -622,7 +622,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_fastl4_udp.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_fastl4_udp.py
@@ -266,7 +266,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No default HTTP LB template was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -297,7 +297,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "The specified service_environment '{0}' was found.".format(self.service_environment)
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -591,7 +591,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -619,7 +619,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_http.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_http.py
@@ -268,7 +268,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No default HTTP LB template was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -297,7 +297,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(str(ex))
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -320,7 +320,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(str(ex))
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -644,7 +644,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -672,7 +672,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_https_offload.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_https_offload.py
@@ -343,7 +343,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No default HTTP LB template was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -374,7 +374,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(str(ex))
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -399,7 +399,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(str(ex))
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -881,7 +881,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -909,7 +909,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_https_waf.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_application_https_waf.py
@@ -351,7 +351,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No default HTTP LB template was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -381,7 +381,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(str(ex))
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -406,7 +406,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(str(ex))
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -906,7 +906,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -934,7 +934,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_device_discovery.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_device_discovery.py
@@ -809,7 +809,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -831,7 +831,7 @@ class ModuleManager(object):
             except ValueError as ex:
                 raise F5ModuleError(str(ex))
 
-            if 'code' in response and response['code'] == 400:
+            if 'code' in response and response['code'] >= 400:
                 if 'message' in response:
                     raise F5ModuleError(response['message'])
                 else:
@@ -1130,7 +1130,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_device_info.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_device_info.py
@@ -1038,7 +1038,7 @@ class ApplicationsFactManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1163,7 +1163,7 @@ class ManagedDevicesFactManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1298,7 +1298,7 @@ class PurchasedPoolLicensesFactManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1445,7 +1445,7 @@ class RegkeyPoolsFactManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1467,7 +1467,7 @@ class RegkeyPoolsFactManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1737,7 +1737,7 @@ class SystemInfoFactManager(BaseManager):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1759,7 +1759,7 @@ class SystemInfoFactManager(BaseManager):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1801,7 +1801,7 @@ class SystemInfoFactManager(BaseManager):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1824,7 +1824,7 @@ class SystemInfoFactManager(BaseManager):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1885,7 +1885,7 @@ class SystemInfoFactManager(BaseManager):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -1967,7 +1967,7 @@ class SystemInfoFactManager(BaseManager):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -2109,7 +2109,7 @@ class VlansFactManager(BaseManager):
             response = resp.json()
         except ValueError as ex:
             raise F5ModuleError(str(ex))
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -2128,7 +2128,7 @@ class VlansFactManager(BaseManager):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_regkey_license.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_regkey_license.py
@@ -178,7 +178,7 @@ class ModuleParameters(Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -391,7 +391,7 @@ class ModuleManager(object):
                 except ValueError as ex:
                     raise F5ModuleError(str(ex))
 
-                if 'code' in response and response['code'] == 400:
+                if 'code' in response and response['code'] >= 400:
                     if 'message' in response:
                         raise F5ModuleError(response['message'])
                     else:
@@ -414,7 +414,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -449,7 +449,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_regkey_license_assignment.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_regkey_license_assignment.py
@@ -246,7 +246,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No device with the specified address was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -274,7 +274,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No pool with the specified name was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -305,7 +305,7 @@ class ModuleParameters(Parameters):
 
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -526,7 +526,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -548,7 +548,7 @@ class ModuleManager(object):
             except ValueError as ex:
                 raise F5ModuleError(str(ex))
 
-            if 'code' in response and response['code'] == 400:
+            if 'code' in response and response['code'] >= 400:
                 if 'message' in response:
                     raise F5ModuleError(response['message'])
                 else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_regkey_pool.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_regkey_pool.py
@@ -139,7 +139,7 @@ class ModuleParameters(Parameters):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -335,7 +335,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -368,7 +368,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_utility_license.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_utility_license.py
@@ -254,7 +254,7 @@ class ModuleManager(object):
 
         if resp.status == 200 and response['totalItems'] == 0:
             return False
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -303,7 +303,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -334,7 +334,7 @@ class ModuleManager(object):
             except ValueError as ex:
                 raise F5ModuleError(str(ex))
 
-            if 'code' in response and response['code'] == 400:
+            if 'code' in response and response['code'] >= 400:
                 if 'message' in response:
                     raise F5ModuleError(response['message'])
                 else:
@@ -408,7 +408,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_utility_license_assignment.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigiq_utility_license_assignment.py
@@ -259,7 +259,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No device with the specified address was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -288,7 +288,7 @@ class ModuleParameters(Parameters):
             raise F5ModuleError(
                 "No offering with the specified name was found."
             )
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -323,7 +323,7 @@ class ModuleParameters(Parameters):
 
         if resp.status == 200 and response['totalItems'] == 0:
             return None
-        elif 'code' in response and response['code'] == 400:
+        elif 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -535,7 +535,7 @@ class ModuleManager(object):
         except ValueError as ex:
             raise F5ModuleError(str(ex))
 
-        if 'code' in response and response['code'] == 400:
+        if 'code' in response and response['code'] >= 400:
             if 'message' in response:
                 raise F5ModuleError(response['message'])
             else:
@@ -557,7 +557,7 @@ class ModuleManager(object):
             except ValueError as ex:
                 raise F5ModuleError(str(ex))
 
-            if 'code' in response and response['code'] == 400:
+            if 'code' in response and response['code'] >= 400:
                 if 'message' in response:
                     raise F5ModuleError(response['message'])
                 else:


### PR DESCRIPTION
Currently, the code only checks for 400 errors in which case an exception is raised.

When the HTTP token expires during a request though, the BigIP responds with a 401 error.

This leads to ugly error messages like this one, which does in no way indicate what's really going on:

```plaintext
Traceback (most recent call last):\n  File \"/home/nomike/.ansible/tmp/ansible-tmp-1744365130.8715017-1746843-240028148910036/AnsiballZ_bigip_virtual_server.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/nomike/.ansible/tmp/ansible-tmp-1744365130.8715017-1746843-240028148910036/AnsiballZ_bigip_virtual_server.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/nomike/.ansible/tmp/ansible-tmp-1744365130.8715017-1746843-240028148910036/AnsiballZ_bigip_virtual_server.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.f5networks.f5_modules.plugins.modules.bigip_virtual_server', init_globals=dict(_module_fqn='ansible_collections.f5networks.f5_modules.plugins.modules.bigip_virtual_server', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 3882, in <module>\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 3875, in main\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 3511, in exec_module\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 3524, in present\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 3547, in update\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 3555, in should_update\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 3585, in _update_changed_options\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 3158, in compare\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 3289, in profiles\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 2066, in profiles\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 1838, in _handle_ssl_profile_nuances\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 1409, in _is_server_ssl_profile\n  File \"/tmp/ansible_bigip_virtual_server_payload_c7vueyp4/ansible_bigip_virtual_server_payload.zip/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py\", line 1400, in _read_current_serverssl_profiles_from_device\nKeyError: 'items'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

With this patch exceptions are raise for 401 errors too and for all other possible HTTP errors (e.g. BigIP becoming unresponsive while being accessed via an HTTP proxy, which would result in a 503 error).

Error messages now mean something:

```plaintext
fatal: [bigipip.server.lan]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": false, "msg": "401 Client Error: X-F5-Auth-Token has expired. for url: https://bigipip.server.lan:443/mgmt/tm/ltm/profile/client-ssl/"}
```


