### PR TITLE
Using environment variables for provider info no longer works, getting "unable to convert to str: 'None'"

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/2440-env-provider-fallback.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/2440-env-provider-fallback.yaml
@@ -1,0 +1,2 @@
+bigfixes:
+  - Support for using environment variables for provider info

--- a/ansible_collections/f5networks/f5_modules/plugins/action/bigip.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/action/bigip.py
@@ -50,7 +50,9 @@ class ActionModule(ActionNetworkModule):
             if any(provider.values()):
                 display.warning("'provider' is unnecessary when using 'network_cli' and will be ignored")
         elif self._play_context.connection == 'local':
-            provider = load_provider(f5_provider_spec, self._task.args)
+            # provider = load_provider(f5_provider_spec, self._task.args)
+            provider = load_provider(f5_provider_spec, self._task.args, module=self._task)
+
             transport = provider['transport'] or transport
 
             display.vvvv('connection transport is %s' % transport, self._play_context.remote_addr)

--- a/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
@@ -12,8 +12,8 @@ import re
 import datetime
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.connection import exec_command
+from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.parsing.convert_bool import (
     BOOLEANS_TRUE, BOOLEANS_FALSE
@@ -29,31 +29,32 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 from .constants import (
     MANAGED_BY_ANNOTATION_MODIFIED, MANAGED_BY_ANNOTATION_VERSION
 )
+from ansible_collections.f5networks.f5_modules.plugins.module_utils.provider_fallback import smart_fallback
 
 f5_provider_spec = {
     'server': dict(
         required=True,
-        fallback=(env_fallback, ['F5_SERVER'])
+        fallback=(smart_fallback, ['F5_SERVER'])
     ),
     'server_port': dict(
         type='int',
         default=443,
-        fallback=(env_fallback, ['F5_SERVER_PORT'])
+        fallback=(smart_fallback, ['F5_SERVER_PORT'])
     ),
     'user': dict(
         required=True,
-        fallback=(env_fallback, ['F5_USER', 'ANSIBLE_NET_USERNAME'])
+        fallback=(smart_fallback, ['F5_USER', 'ANSIBLE_NET_USERNAME'])
     ),
     'password': dict(
         required=True,
         no_log=True,
         aliases=['pass', 'pwd'],
-        fallback=(env_fallback, ['F5_PASSWORD', 'ANSIBLE_NET_PASSWORD']),
+        fallback=(smart_fallback, ['F5_PASSWORD', 'ANSIBLE_NET_PASSWORD']),
     ),
     'validate_certs': dict(
         type='bool',
         default='yes',
-        fallback=(env_fallback, ['F5_VALIDATE_CERTS'])
+        fallback=(smart_fallback, ['F5_VALIDATE_CERTS'])
     ),
     'transport': dict(
         choices=['rest'],
@@ -62,8 +63,8 @@ f5_provider_spec = {
     'timeout': dict(type='int'),
     'no_f5_teem': dict(
         type='bool',
-        default='no',
-        fallback=(env_fallback, ['F5_TEEM', 'F5_TELEMETRY_OFF'])
+        default=False,
+        fallback=(smart_fallback, ['F5_TEEM', 'F5_TELEMETRY_OFF'])
     ),
     'auth_provider': dict(),
 }

--- a/ansible_collections/f5networks/f5_modules/plugins/module_utils/provider_fallback.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/module_utils/provider_fallback.py
@@ -1,0 +1,22 @@
+import os
+
+def smart_fallback(module, varnames):
+    """
+    Compatible with Ansible's load_provider() fallback logic.
+    1. Checks Ansible task-level environment (via `environment:`)
+    2. Falls back to process env (os.environ)
+    """
+    try:
+        if module and hasattr(module._task, 'environment'):
+            env = module._task.environment
+            for var in varnames:
+                if var in env:
+                    return env[var]
+    except Exception:
+        pass
+
+    for var in varnames:
+        if var in os.environ:
+            return os.environ[var]
+
+    return None


### PR DESCRIPTION
Issue: Using environment variables for provider info no longer works, getting "unable to convert to str: 'None'"

bug id: #2440 

Tested the below cases with multiple tasks in a playbook

1st case:
---------
  environment:
    F5_SERVER: "10.218.129.114"
    F5_SERVER_PORT: "443"
    F5_USER: "admin"
    F5_PASSWORD: "admin"
    F5_VALIDATE_CERTS: "no"

2nd case:
----------
  vars:
    provider:
      server: 10.218.129.114
      server_port: 443
      user: admin
      password: admin
      validate_certs: no

3rd case:
----------
export the environment variables over bash where os.env read variables
  export F5_SERVER="1.1.1.1"
  export F5_USER="admin"
  export F5_PASSWORD="weffefrefef"
  export F5_VALIDATE_CERTS="no"
  export F5_SERVER_PORT="443"

and configure the provider with the environment variables

  vars:
    provider:
      server: "{{ lookup('env', 'F5_SERVER') }}"
      server_port: "{{ lookup('env', 'F5_SERVER_PORT') | default('443') | int }}"
      user: "{{ lookup('env', 'F5_USER') }}"
      password: "{{ lookup('env', 'F5_PASSWORD') }}"
      validate_certs: "{{ lookup('env', 'F5_VALIDATE_CERTS') | default('no') | bool }}"

