### PR TITLE
fix: metadata issue where defaults are set when updating w/existing v…

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_virtual_server.py
@@ -3440,18 +3440,21 @@ class Difference(object):
 
     @property
     def metadata(self):
+        if not self.want.insert_metadata:
+            return None
         if self.want.metadata is None:
             return None
-        elif len(self.want.metadata) == 0 and self.have.metadata is None:
-            return None
-        elif len(self.want.metadata) == 0 and not self.want.insert_metadata:
-            return None
-        elif len(self.want.metadata) == 0 and self.want.insert_metadata:
+        if len(self.want.metadata) == 0 and self.want.insert_metadata:
             return []
-        elif self.have.metadata is None:
+        if self.want.insert_metadata != self.have.insert_metadata:
             return self.want.metadata
-        result = self._diff_complex_items(self.want.metadata, self.have.metadata)
-        return result
+        if self.have.metadata is None:
+            return self.want.metadata
+        w = self.to_tuple(self.want.metadata)
+        h = self.to_tuple(self.have.metadata)
+        if set(w) == set(h):
+            return None
+        return self.want.metadata
 
     @property
     def type(self):


### PR DESCRIPTION
Fix for issue #2509 that prevents updating metadata with defaults when the user provided metadata is identical to the what is already configured on the virtual server.
Fixed a second issue where specifying only part of the existing metadata would not remove the parts that are missing from the new metadata.