### PR TITLE
fix: allow spaces in gtm names

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
@@ -262,6 +262,7 @@ def transform_name(partition='', name='', sub_path=''):
     if name:
         name = name.replace('/', '~')
         name = name.replace('%', '%25')
+        name = name.replace(' ', '%20')
 
     if partition:
         partition = partition.replace('/', '~')


### PR DESCRIPTION
## Problem

The `transform_name()` utility function in `module_utils/common.py` is used by GTM/DNS modules to build REST API URI segments. It correctly encodes `/` as `~` and `%` as `%25`, but does not encode spaces as `%20`. 

BIG-IP allows spaces in GTM/DNS object names (e.g., a datacenter named `"New York"` — as demonstrated in `bigip_gtm_datacenter`'s own module examples). When a name with spaces is passed through `transform_name`, the resulting URI contains a literal space (e.g., `/mgmt/tm/gtm/datacenter/~Common~New York`), causing API calls to fail with 404 or malformed request errors.

## Fix

Added `name = name.replace(' ', '%20')` to `transform_name()`, placed after the existing `%` → `%25` encoding to prevent double-encoding.

This is a single-line change that fixes all 19 affected modules at once:

- `bigip_gtm_datacenter`
- `bigip_gtm_dns_listener`
- `bigip_gtm_monitor_bigip`
- `bigip_gtm_monitor_external`
- `bigip_gtm_monitor_firepass`
- `bigip_gtm_monitor_http`
- `bigip_gtm_monitor_https`
- `bigip_gtm_monitor_tcp`
- `bigip_gtm_monitor_tcp_half_open`
- `bigip_gtm_pool`
- `bigip_gtm_pool_member`
- `bigip_gtm_server`
- `bigip_gtm_topology_region`
- `bigip_gtm_virtual_server`
- `bigip_gtm_wide_ip`
- `bigip_dns_cache_resolver`
- `bigip_dns_nameserver`
- `bigip_dns_resolver`
- `bigip_dns_zone`

**Note:** `bigip_gtm_topology_record` already handled spaces correctly with inline `name.replace(' ', '%20').replace('/', '~')` calls and does not use `transform_name`, so it is unaffected by this change.

## Testing

Verified that `transform_name` correctly handles:
- Names with spaces: `transform_name('Common', 'New York')` → `~Common~New%20York`
- Names without spaces (no regression): `transform_name('Common', 'foo')` → `~Common~foo`
- Names with slashes: `transform_name('Common', 'bar/baz')` → `~Common~bar~baz`
- Names with `%`: `transform_name('Common', '100%')` → `~Common~100%25`
- Names with both `%` and spaces (no double-encoding): `transform_name('Common', 'my 100% pool')` → `~Common~my%20100%25%20pool`
- Fully-qualified names with spaces: `transform_name('Common', '/Common/New York')` → `~Common~New%20York`