### PR TITLE
fix: allow underscore in wideip fqdn

### DIFF
--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-gtm-spaces-in-names.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-gtm-spaces-in-names.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - Allow spaces in GTM/DNS object names by encoding them in REST API URI construction

--- a/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-gtm-wideip-underscore-fqdn.yaml
+++ b/ansible_collections/f5networks/f5_modules/changelogs/fragments/fix-gtm-wideip-underscore-fqdn.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - Allow underscores in GTM Wide IP names, which are valid in DNS names and the BIG-IP

--- a/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
@@ -243,7 +243,7 @@ def is_valid_fqdn(host):
     if len(host) > 255:
         return False
     host = host.rstrip(".")
-    allowed = re.compile(r'(?!-)[A-Z0-9-*]{1,63}(?<!-)$', re.IGNORECASE)
+    allowed = re.compile(r'(?!-)[A-Z0-9_*-]{1,63}(?<!-)$', re.IGNORECASE)
     result = all(allowed.match(x) for x in host.split("."))
     if result:
         parts = host.split('.')

--- a/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/module_utils/common.py
@@ -237,6 +237,10 @@ def is_valid_fqdn(host):
     * If the hyphen is used, it is not permitted to appear at
       either the beginning or end of a label
 
+    Note: As a BIG-IP-specific extension, underscores are also permitted in
+    labels. This deviates from the RFCs above but is necessary for GTM Wide IP
+    names (e.g., SRV records like _sip._tcp.example.com).
+
     :param host:
     :return:
     """

--- a/ansible_collections/f5networks/f5_modules/tests/unit/module_utils/network/f5/test_common.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/module_utils/network/f5/test_common.py
@@ -1,28 +1,17 @@
-from __future__ import absolute_import, division, print_function
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 import sys
-from unittest.mock import MagicMock
 
 import pytest
 
-# Mock heavy dependencies so we can import common.py without ansible/netcommon installed
-for mod_name in [
-    'ansible', 'ansible.module_utils', 'ansible.module_utils._text',
-    'ansible.module_utils.connection', 'ansible.module_utils.basic',
-    'ansible.module_utils.six', 'ansible.module_utils.parsing',
-    'ansible.module_utils.parsing.convert_bool',
-    'ansible_collections.ansible',
-    'ansible_collections.ansible.netcommon',
-    'ansible_collections.ansible.netcommon.plugins',
-    'ansible_collections.ansible.netcommon.plugins.module_utils',
-    'ansible_collections.ansible.netcommon.plugins.module_utils.network',
-    'ansible_collections.ansible.netcommon.plugins.module_utils.network.common',
-    'ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config',
-    'ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils',
-    'ansible_collections.f5networks.f5_modules.plugins.module_utils.constants',
-]:
-    if mod_name not in sys.modules:
-        sys.modules[mod_name] = MagicMock()
+if sys.version_info < (2, 7):
+    pytestmark = pytest.mark.skip("F5 Ansible modules require Python >= 2.7")
 
 from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import is_valid_fqdn
 

--- a/ansible_collections/f5networks/f5_modules/tests/unit/module_utils/network/f5/test_common.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/module_utils/network/f5/test_common.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mock heavy dependencies so we can import common.py without ansible/netcommon installed
+for mod_name in [
+    'ansible', 'ansible.module_utils', 'ansible.module_utils._text',
+    'ansible.module_utils.connection', 'ansible.module_utils.basic',
+    'ansible.module_utils.six', 'ansible.module_utils.parsing',
+    'ansible.module_utils.parsing.convert_bool',
+    'ansible_collections.ansible',
+    'ansible_collections.ansible.netcommon',
+    'ansible_collections.ansible.netcommon.plugins',
+    'ansible_collections.ansible.netcommon.plugins.module_utils',
+    'ansible_collections.ansible.netcommon.plugins.module_utils.network',
+    'ansible_collections.ansible.netcommon.plugins.module_utils.network.common',
+    'ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config',
+    'ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils',
+    'ansible_collections.f5networks.f5_modules.plugins.module_utils.constants',
+]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = MagicMock()
+
+from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import is_valid_fqdn
+
+
+class TestIsValidFqdn:
+    """Tests for is_valid_fqdn covering normal, underscore, wildcard, and invalid inputs."""
+
+    def test_standard_fqdn(self):
+        assert is_valid_fqdn("www.example.com") is True
+
+    def test_subdomain_fqdn(self):
+        assert is_valid_fqdn("host.sub.example.com") is True
+
+    def test_trailing_dot(self):
+        assert is_valid_fqdn("www.example.com.") is True
+
+    def test_underscore_srv_record(self):
+        assert is_valid_fqdn("_sip._tcp.example.com") is True
+
+    def test_underscore_in_label(self):
+        assert is_valid_fqdn("my_host.example.com") is True
+
+    def test_wildcard_fqdn(self):
+        assert is_valid_fqdn("*.example.com") is True
+
+    def test_single_label_not_fqdn(self):
+        assert is_valid_fqdn("localhost") is False
+
+    def test_empty_string(self):
+        assert is_valid_fqdn("") is False
+
+    def test_too_long(self):
+        # 256 characters exceeds the 255 max
+        long_host = "a" * 63 + "." + "b" * 63 + "." + "c" * 63 + "." + "d" * 63 + ".e"
+        assert is_valid_fqdn(long_host) is False
+
+    def test_label_too_long(self):
+        # A single label exceeding 63 characters
+        assert is_valid_fqdn("a" * 64 + ".example.com") is False
+
+    def test_hyphen_at_start_of_label(self):
+        assert is_valid_fqdn("-host.example.com") is False
+
+    def test_hyphen_at_end_of_label(self):
+        assert is_valid_fqdn("host-.example.com") is False
+
+    def test_hyphen_in_middle(self):
+        assert is_valid_fqdn("my-host.example.com") is True
+
+    def test_numeric_labels(self):
+        assert is_valid_fqdn("123.456.789.com") is True
+
+    def test_invalid_characters(self):
+        assert is_valid_fqdn("host!name.example.com") is False


### PR DESCRIPTION
The `is_valid_fqdn()` validation function in `module_utils/common.py` rejects DNS names containing underscores, causing `bigip_gtm_wide_ip` to fail with `"The provided name must be a valid FQDN"` for names like `my_app.example.com` or `_sip._tcp.example.com`.

Underscores are valid in DNS names and accepted by BIG-IP. They are also required by SRV, DMARC, and DKIM record types.

Added `_` to the `is_valid_fqdn` regex character class. The `is_valid_hostname()` function was intentionally left unchanged, as hostname validation correctly excludes underscores per RFC 952/1123.

**Affected module:** `bigip_gtm_wide_ip` — the only consumer of `is_valid_fqdn`