### PR TITLE
docs: : correct force param for apm import

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_apm_policy_import.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_apm_policy_import.py
@@ -35,7 +35,8 @@ options:
     type: path
   force:
     description:
-      - When set to C(true) any existing policy with the same name will be overwritten by the new import.
+      - When set to C(true) and a policy with the same name already exists, the module will re-run the import,
+        and a new policy is created with a number appended to the previous name.
       - If a policy does not exist, this setting is ignored.
     default: false
     type: bool


### PR DESCRIPTION
MR description:

The force parameter description for the bigip_apm_policy_import module incorrectly stated that an existing policy would be overwritten by the new import. In reality, due to the nature of APM, the existing policy is not replaced in place. Instead, a new policy is created with a number appended to the previous name.

This change updates the documentation to accurately reflect the actual behavior of the module.