### PR TITLE
[bigip_profile_server_ssl] Added missing Options to Argument spec

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
@@ -805,7 +805,7 @@ class ArgumentSpec(object):
                     'no-dtls',
                     'no-dtlsv1.0',
                     'no-dtlsv1.1',
-                    'no-dtlsv1.2',      
+                    'no-dtlsv1.2',
                     'no-session-resumption-on-renegotiation',
                     'no-tlsv1.1',
                     'no-tlsv1.2',

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
@@ -798,6 +798,9 @@ class ArgumentSpec(object):
                     'dont-insert-empty-fragments',
                     'no-ssl',
                     'no-dtls',
+                    'no-dtlsv1.0',
+                    'no-dtlsv1.1',
+                    'no-dtlsv1.2',        
                     'no-session-resumption-on-renegotiation',
                     'no-tlsv1.1',
                     'no-tlsv1.2',
@@ -807,6 +810,8 @@ class ArgumentSpec(object):
                     'no-sslv3',
                     'no-tls',
                     'no-tlsv1',
+                    'gmsslv1.1',
+                    'passive-close',
                     'none',
                 ]
             ),

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
@@ -125,9 +125,9 @@ options:
       - dont-insert-empty-fragments
       - no-ssl
       - no-dtls
-      - no-dtls1.0
-      - no-dtls1.1
-      - no-dtls1.2
+      - no-dtlsv1.0
+      - no-dtlsv1.1
+      - no-dtlsv1.2
       - no-session-resumption-on-renegotiation
       - no-tlsv1.1
       - no-tlsv1.2

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
@@ -125,6 +125,9 @@ options:
       - dont-insert-empty-fragments
       - no-ssl
       - no-dtls
+      - no-dtls1.0
+      - no-dtls1.1
+      - no-dtls1.2
       - no-session-resumption-on-renegotiation
       - no-tlsv1.1
       - no-tlsv1.2
@@ -134,6 +137,8 @@ options:
       - no-sslv3
       - no-tls
       - no-tlsv1
+      - gmsslv1.1
+      - passive-close
       - "none"
   passphrase:
     description:

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_profile_server_ssl.py
@@ -805,7 +805,7 @@ class ArgumentSpec(object):
                     'no-dtls',
                     'no-dtlsv1.0',
                     'no-dtlsv1.1',
-                    'no-dtlsv1.2',        
+                    'no-dtlsv1.2',      
                     'no-session-resumption-on-renegotiation',
                     'no-tlsv1.1',
                     'no-tlsv1.2',


### PR DESCRIPTION
Added missing Options to Argument spec for:

- no-dtlsv1.0
- no-dtlsv1.1
- no-dtlsv1.2
- gmsslv1.1
- passive-close