### PR TITLE
feat: add ipport as valid cmp_hash choice [AUTOTOOL-5333]

### DIFF
--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_vlan.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_vlan.py
@@ -74,8 +74,8 @@ options:
       - Specifies how the traffic on the VLAN is disaggregated. The value
         you select determines the traffic disaggregation method. You can choose to
         disaggregate traffic based on C(source-address) (the source IP address),
-        C(destination-address) (destination IP address), or C(default), which
-        specifies the default CMP hash uses L4 ports.
+        C(destination-address) (destination IP address), C(ipport) (source IP address
+        and port), or C(default), which specifies the default CMP hash uses L4 ports.
       - When creating a new VLAN, if this parameter is not specified, the default
         is C(default).
     type: str

--- a/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_vlan.py
+++ b/ansible_collections/f5networks/f5_modules/plugins/modules/bigip_vlan.py
@@ -90,6 +90,7 @@ options:
       - source
       - dst
       - src
+      - ipport
   dag_tunnel:
     description:
       - Specifies how the disaggregator (DAG) distributes received tunnel-encapsulated
@@ -505,6 +506,8 @@ class ModuleParameters(Parameters):
             return 'src-ip'
         if self._values['cmp_hash'] in ['destination-address', 'dest', 'dst-ip', 'destination', 'dst']:
             return 'dst-ip'
+        if self._values['cmp_hash'] == 'ipport':
+            return 'ipport'
         else:
             return 'default'
 
@@ -929,8 +932,16 @@ class ArgumentSpec(object):
             cmp_hash=dict(
                 choices=[
                     'default',
-                    'destination-address', 'dest', 'dst-ip', 'destination', 'dst',
-                    'source-address', 'src', 'src-ip', 'source'
+                    'destination-address',
+                    'source-address',
+                    'dst-ip',
+                    'src-ip',
+                    'dest',
+                    'destination',
+                    'source',
+                    'dst',
+                    'src',
+                    'ipport'
                 ]
             ),
             dag_tunnel=dict(

--- a/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_vlan.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_vlan.py
@@ -365,32 +365,3 @@ class TestManager(unittest.TestCase):
 
         assert results['changed'] is True
         assert results['cmp_hash'] == 'ipport'
-
-    def test_create_vlan_with_cmp_hash_ipport(self, *args):
-        set_module_args(dict(
-            name='somevlan',
-            description='fakevlan',
-            cmp_hash='ipport',
-            partition='Common',
-            provider=dict(
-                server='localhost',
-                password='password',
-                user='admin'
-            )
-        ))
-
-        module = AnsibleModule(
-            argument_spec=self.spec.argument_spec,
-            supports_check_mode=self.spec.supports_check_mode,
-            mutually_exclusive=self.spec.mutually_exclusive
-        )
-
-        # Override methods to force specific logic in the module to happen
-        mm = ModuleManager(module=module)
-        mm.create_on_device = Mock(return_value=True)
-        mm.exists = Mock(return_value=False)
-
-        results = mm.exec_module()
-
-        assert results['changed'] is True
-        assert results['cmp_hash'] == 'ipport'

--- a/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_vlan.py
+++ b/ansible_collections/f5networks/f5_modules/tests/unit/modules/network/f5/test_bigip_vlan.py
@@ -336,3 +336,61 @@ class TestManager(unittest.TestCase):
 
         assert results['changed'] is True
         assert results['description'] == 'changed_that'
+
+    def test_create_vlan_with_cmp_hash_ipport(self, *args):
+        set_module_args(dict(
+            name='somevlan',
+            description='fakevlan',
+            cmp_hash='ipport',
+            partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
+        ))
+
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
+        )
+
+        # Override methods to force specific logic in the module to happen
+        mm = ModuleManager(module=module)
+        mm.create_on_device = Mock(return_value=True)
+        mm.exists = Mock(return_value=False)
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['cmp_hash'] == 'ipport'
+
+    def test_create_vlan_with_cmp_hash_ipport(self, *args):
+        set_module_args(dict(
+            name='somevlan',
+            description='fakevlan',
+            cmp_hash='ipport',
+            partition='Common',
+            provider=dict(
+                server='localhost',
+                password='password',
+                user='admin'
+            )
+        ))
+
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode,
+            mutually_exclusive=self.spec.mutually_exclusive
+        )
+
+        # Override methods to force specific logic in the module to happen
+        mm = ModuleManager(module=module)
+        mm.create_on_device = Mock(return_value=True)
+        mm.exists = Mock(return_value=False)
+
+        results = mm.exec_module()
+
+        assert results['changed'] is True
+        assert results['cmp_hash'] == 'ipport'


### PR DESCRIPTION
### Summary

Adds support for the `ipport` CMP hash disaggregation method in the `bigip_vlan` module, resolving a gap between module capabilities and BIG-IP device functionality. This choice was available on BIG-IP systems but missing from the module's documented options.

### Changes

**Module:**
- Added `ipport` to the `cmp_hash` parameter choices in `bigip_vlan.py`

**Tests:**
- Added `test_create_vlan_with_cmp_hash_ipport()` test case in `test_bigip_vlan.py` to verify the new choice is accepted and applied correctly

### Testing

- New unit test case validates VLAN creation with `cmp_hash='ipport'` parameter
- Test verifies module state change and parameter value assertion
- Existing test suite remains unaffected; all test patterns follow established conventions

### Checklist

- [x] Unit tests added and verified
- [x] Code follows project conventions
- [x] No security concerns identified